### PR TITLE
Switch to 64-bit indices

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,8 +108,8 @@ This ensures that regardless of numerical type used for `REAL`, that infinite va
 
 The member functions for initializing the rows and columns are
 ```
-setNumCols( int ncols )
-setNumRows( int nrows )
+setNumCols( int64_t ncols )
+setNumRows( int64_t nrows )
 ```
 After calling those functions the problem will have no nonzero entries but the given number of columns and rows. The left and right hand side values of rows the rows are set to $0$ as well as the lower and upper bounds of the columns. Additionally all columns are initialized as continuous columns.
 
@@ -117,45 +117,45 @@ Next the following member functions can be used to alter the bound information a
 
 *   alter objective coefficient for columns
     ```
-    setObj( int col, REAL val )
+    setObj( int64_t col, REAL val )
     ```
 *   alter bound information for columns
     ```
-    setColLb( int col, REAL lb )
-    setColLbInf( int col, bool isInfinite )
-    setColUb( int col, REAL ub )
-    setColUbInf( int col, bool isInfinite )
+    setColLb( int64_t col, REAL lb )
+    setColLbInf( int64_t col, bool isInfinite )
+    setColUb( int64_t col, REAL ub )
+    setColUbInf( int64_t col, bool isInfinite )
     ```
 *   mark column to be restricted to integral values or not
     ```
-    setColIntegral( int col, bool isIntegral )
+    setColIntegral( int64_t col, bool isIntegral )
     ```
 *   alter left and right hand sides of rows
     ```
-    setRowLhsInf( int row, bool isInfinite )
-    setRowRhsInf( int row, bool isInfinite )
-    setRowLhs( int row, REAL lhsval )
-    setRowRhs( int row, REAL rhsval )
+    setRowLhsInf( int64_t row, bool isInfinite )
+    setRowRhsInf( int64_t row, bool isInfinite )
+    setRowLhs( int64_t row, REAL lhsval )
+    setRowRhs( int64_t row, REAL rhsval )
     ```
 *   set names of rows, columns, and the problem
     ```
-    setRowName( int row, Str&& name )
-    setColName( int col, Str&& name )
+    setRowName( int64_t row, Str&& name )
+    setColName( int64_t col, Str&& name )
     setProblemName( Str&& name )
     ```
 
 Adding nonzeros to the problem can be done with individual nonzero values, row-based, or column-based using the following functions:
 ```
    /// add the nonzero entries for the given column
-   addColEntries( int col, int len, const int* rows, const R* vals )
+   addColEntries( int64_t col, int64_t len, const int64_t* rows, const R* vals )
    /// add a nonzero entry for the given row and column
-   addEntry( int row, int col, const REAL& val )
+   addEntry( int64_t row, int64_t col, const REAL& val )
    /// add the nonzero entries for the given row
-   addRowEntries( int row, int len, const int* cols, const R* vals )
+   addRowEntries( int64_t row, int64_t len, const int64_t* cols, const R* vals )
 ```
 All those functions can be called multiple times, but a nonzero entry for a particular column in a particular row should only be added once.
 For maximum efficiency the member function
-`papilo::ProblemBuilder<REAL>::reserve(int nnz, int nrows, int ncols)` should be used to reserve all required memory before adding nonzeros.
+`papilo::ProblemBuilder<REAL>::reserve(int nnz, int64_t nrows, int64_t ncols)` should be used to reserve all required memory before adding nonzeros.
 
 Finally calling `papilo::ProblemBuilder<REAL>::build()` will return an instance of `papilo::Problem<REAL>` with the information that was given to the builder. The builder can be reused afterwards.
 

--- a/src/convMPS.cpp
+++ b/src/convMPS.cpp
@@ -54,14 +54,14 @@ convMPS( const Problem<double>& prob )
     */
 
    // Get all relevant data
-   int nCols = prob.getNCols();
-   int nRows = prob.getNRows();
+   int64_t nCols = prob.getNCols();
+   int64_t nRows = prob.getNRows();
    const Objective<double>& obj = prob.getObjective();
    const ConstraintMatrix<double>& cm = prob.getConstraintMatrix();
    Vec<double> rowlhs = cm.getLeftHandSides();
    Vec<double> rowrhs = cm.getRightHandSides();
    Vec<RowFlags> row_flags = cm.getRowFlags();
-   const int nnz = cm.getNnz();
+   const int64_t nnz = cm.getNnz();
    const VariableDomains<double> vd = prob.getVariableDomains();
    const Vec<std::string> cnames = prob.getVariableNames();
    const Vec<std::string> rnames = prob.getConstraintNames();
@@ -75,66 +75,66 @@ convMPS( const Problem<double>& prob )
    fmt::print( "}};\n" );
    // Columns
    fmt::print( "   Vec<double> lbs{{" );
-   for( int c = 0; c < nCols; ++c )
+   for( int64_t c = 0; c < nCols; ++c )
       fmt::print( "{},", vd.lower_bounds[c] );
    fmt::print( "}};\n" );
    fmt::print( "   Vec<uint8_t> lbInf{{" );
-   for( int c = 0; c < nCols; ++c )
+   for( int64_t c = 0; c < nCols; ++c )
       fmt::print( "{},", vd.flags[c].test( ColFlag::kLbInf ) ? 1 : 0 );
    fmt::print( "}};\n" );
    fmt::print( "   Vec<double> ubs{{" );
-   for( int c = 0; c < nCols; ++c )
+   for( int64_t c = 0; c < nCols; ++c )
       fmt::print( "{},", vd.upper_bounds[c] );
    fmt::print( "}};\n" );
    fmt::print( "   Vec<uint8_t> ubInf{{" );
-   for( int c = 0; c < nCols; ++c )
+   for( int64_t c = 0; c < nCols; ++c )
       fmt::print( "{},", vd.flags[c].test( ColFlag::kUbInf ) ? 1 : 0 );
    fmt::print( "}};\n" );
    fmt::print( "   Vec<uint8_t> isIntegral{{" );
-   for( int c = 0; c < nCols; ++c )
+   for( int64_t c = 0; c < nCols; ++c )
       fmt::print( "{},", vd.flags[c].test( ColFlag::kIntegral ) ? 1 : 0 );
    fmt::print( "}};\n" );
    // Rows
    fmt::print( "   Vec<uint8_t> lhsIsInf{{" );
-   for( int r = 0; r < nRows; ++r )
+   for( int64_t r = 0; r < nRows; ++r )
       fmt::print( "{},", row_flags[r].test( RowFlag::kLhsInf ) ? 1 : 0 );
    fmt::print( "}};\n" );
    fmt::print( "   Vec<double> lhs{{" );
-   for( int r = 0; r < nRows; ++r )
+   for( int64_t r = 0; r < nRows; ++r )
       fmt::print( "{},", rowlhs[r] );
    fmt::print( "}};\n" );
    fmt::print( "   Vec<uint8_t> rhsIsInf{{" );
-   for( int r = 0; r < nRows; ++r )
+   for( int64_t r = 0; r < nRows; ++r )
       fmt::print( "{},", row_flags[r].test( RowFlag::kRhsInf ) ? 1 : 0 );
    fmt::print( "}};\n" );
    fmt::print( "   Vec<double> rhs{{" );
-   for( int r = 0; r < nRows; ++r )
+   for( int64_t r = 0; r < nRows; ++r )
       fmt::print( "{},", rowrhs[r] );
    fmt::print( "}};\n" );
    // Entries ( Nonzero Matrix values )
    fmt::print( "   Vec<std::tuple<int, int, double>> entries{{" );
-   for( int r = 0; r < nRows; ++r )
+   for( int64_t r = 0; r < nRows; ++r )
    {
       const SparseVectorView<double>& rc = cm.getRowCoefficients( r );
-      const int len = rc.getLength();
-      const int* indices = rc.getIndices();
+      const int64_t len = rc.getLength();
+      const int64_t* indices = rc.getIndices();
       const double* vals = rc.getValues();
-      for( int i = 0; i < len; ++i )
+      for( int64_t i = 0; i < len; ++i )
          fmt::print( "std::tuple<int, int, double>{{{},{},{}}},", r,
                      *( indices + i ), *( vals + i ) );
    }
    fmt::print( "}};\n" );
    // Names
    fmt::print( "   Vec<std::string> rnames{{" );
-   for( int r = 0; r < nRows; ++r )
+   for( int64_t r = 0; r < nRows; ++r )
       fmt::print( "\"{}\",", rnames[r] );
    fmt::print( "}};\n" );
    fmt::print( "   Vec<std::string> cnames{{" );
-   for( int c = 0; c < nCols; ++c )
+   for( int64_t c = 0; c < nCols; ++c )
       fmt::print( "\"{}\",", cnames[c] );
    fmt::print( "}};\n" );
    // Set problem Builder
-   fmt::print( "   int nCols = {}; int nRows = {};\n", nCols, nRows );
+   fmt::print( "   int64_t nCols = {}; int64_t nRows = {};\n", nCols, nRows );
    fmt::print( "   ProblemBuilder<double> pb;\n" );
    fmt::print( "   pb.reserve( {},{},{} );\n", nnz, nRows, nCols );
    fmt::print( "   pb.setNumRows( nRows );\n" );

--- a/src/papilo/core/ConstraintMatrix.hpp
+++ b/src/papilo/core/ConstraintMatrix.hpp
@@ -50,7 +50,7 @@ class SparseVectorView
    SparseVectorView<REAL>&
    operator=( const SparseVectorView<REAL>& ) = default;
 
-   SparseVectorView( const REAL* vals, const int* inds, int len )
+   SparseVectorView( const REAL* vals, const int64_t* inds, int64_t len )
        : vals( vals ), indices( inds ), len( len )
    {
    }
@@ -61,7 +61,7 @@ class SparseVectorView
       return vals;
    }
 
-   const int*
+   const int64_t*
    getIndices() const
    {
       return indices;
@@ -78,7 +78,7 @@ class SparseVectorView
    {
       REAL maxabsval = 0.0;
 
-      for( int i = 0; i != len; ++i )
+      for( int64_t i = 0; i != len; ++i )
          maxabsval = std::max( REAL( abs( vals[i] ) ), maxabsval );
 
       return maxabsval;
@@ -89,7 +89,7 @@ class SparseVectorView
    {
       REAL minabsval;
 
-      for( int i = 0; i != len; ++i )
+      for( int64_t i = 0; i != len; ++i )
       {
          if( i == 0 )
             minabsval = abs( vals[0] );
@@ -108,7 +108,7 @@ class SparseVectorView
          REAL maxabsval = abs( vals[0] );
          REAL minabsval = maxabsval;
 
-         for( int i = 1; i != len; ++i )
+         for( int64_t i = 1; i != len; ++i )
          {
             maxabsval = std::max( REAL( abs( vals[i] ) ), maxabsval );
             minabsval = std::min( REAL( abs( vals[i] ) ), minabsval );
@@ -128,7 +128,7 @@ class SparseVectorView
          REAL maxabsval = abs( vals[0] );
          REAL minabsval = maxabsval;
 
-         for( int i = 1; i != len; ++i )
+         for( int64_t i = 1; i != len; ++i )
          {
             maxabsval = Num<REAL>::max( abs( vals[i] ), maxabsval );
             minabsval = Num<REAL>::min( abs( vals[i] ), minabsval );
@@ -142,8 +142,8 @@ class SparseVectorView
 
  private:
    const REAL* vals;
-   const int* indices;
-   int len;
+   const int64_t* indices;
+   int64_t len;
 };
 
 /// type representing the constraint matrix including the left and right hand
@@ -178,12 +178,12 @@ class ConstraintMatrix
       // rowranges[i].end);
       //}
 
-      for( int i = 0; i < cons_matrix.getNRows(); ++i )
+      for( int64_t i = 0; i < cons_matrix.getNRows(); ++i )
          rowsize.push_back( rowranges[i].end - rowranges[i].start );
 
       auto colranges = cons_matrix_transp.getRowRanges();
 
-      for( int i = 0; i < cons_matrix.getNCols(); ++i )
+      for( int64_t i = 0; i < cons_matrix.getNCols(); ++i )
          colsize.push_back( colranges[i].end - colranges[i].start );
    }
 
@@ -222,7 +222,7 @@ class ConstraintMatrix
                              cons_matrix.getNRows() );
    }
 
-   const int*
+   const int64_t*
    getColumns() const
    {
       return cons_matrix.getColumns();
@@ -231,7 +231,7 @@ class ConstraintMatrix
    /// returns a sparse vector view on the row coefficients and their column
    /// indices
    SparseVectorView<REAL>
-   getRowCoefficients( int r ) const
+   getRowCoefficients( int64_t r ) const
    {
       assert( r >= 0 && r < getNRows() );
 
@@ -246,7 +246,7 @@ class ConstraintMatrix
    /// returns a sparse vector view on the column coefficients and their row
    /// indices
    SparseVectorView<REAL>
-   getColumnCoefficients( int c ) const
+   getColumnCoefficients( int64_t c ) const
    {
       assert( c >= 0 && c < getNCols() );
 
@@ -261,7 +261,7 @@ class ConstraintMatrix
    /// returns maximal change of constraint feasibility for the given change of
    /// value in the given column
    REAL
-   getMaxFeasChange( int col, const REAL& val ) const
+   getMaxFeasChange( int64_t col, const REAL& val ) const
    {
       return abs( val * getColumnCoefficients( col ).getMaxAbsValue() );
    }
@@ -309,7 +309,7 @@ class ConstraintMatrix
    /// modify the value of an element from the left hand side
    template <bool infval = false>
    void
-   modifyLeftHandSide( const int index, const REAL& value = 0 )
+   modifyLeftHandSide( const int64_t index, const REAL& value = 0 )
    {
       assert( index >= 0 );
       assert( index < getNRows() );
@@ -334,7 +334,7 @@ class ConstraintMatrix
    /// modify the value of an element from the right hand side
    template <bool infval = false>
    void
-   modifyRightHandSide( const int index, const REAL& value = 0 )
+   modifyRightHandSide( const int64_t index, const REAL& value = 0 )
    {
       assert( index >= 0 );
       assert( index < getNRows() );
@@ -358,14 +358,14 @@ class ConstraintMatrix
 
    /// mark given row as redundant
    void
-   markRowRedundant( const int row )
+   markRowRedundant( const int64_t row )
    {
       flags[row].set( RowFlag::kRedundant );
    }
 
    /// is given row redundant
    bool
-   isRowRedundant( const int row ) const
+   isRowRedundant( const int64_t row ) const
    {
       return flags[row].test( RowFlag::kRedundant );
    }
@@ -380,7 +380,7 @@ class ConstraintMatrix
 
    /// returns reference to the row indices of the
    /// column-wise matrix (cons_matrix_transp) for solvers
-   const int*
+   const int64_t*
    getTransposeRowIndices() const
    {
       return cons_matrix_transp.getColumns();
@@ -388,7 +388,7 @@ class ConstraintMatrix
 
    /// returns reference to a sequence containin the start indices
    /// of the columns in the column-wise matrix (cons_matrix_transp)
-   Vec<int>
+   Vec<int64_t>
    getTransposeColStart() const
    {
       return cons_matrix_transp.getRowStarts();
@@ -400,34 +400,34 @@ class ConstraintMatrix
    /// removed.
    /// The first vector of the pair stores the mapping for the rows, the second
    /// vector stores the mapping of the columns.
-   std::pair<Vec<int>, Vec<int>>
+   std::pair<Vec<int64_t>, Vec<int64_t>>
    compress( bool full = false );
 
    void
-   deleteRowsAndCols( Vec<int>& deletedRows, Vec<int>& deletedColumns,
+   deleteRowsAndCols( Vec<int64_t>& deletedRows, Vec<int64_t>& deletedColumns,
                       Vec<RowActivity<REAL>>& activities,
-                      Vec<int>& singletonRows, Vec<int>& singletonCols,
-                      Vec<int>& emptyCols );
+                      Vec<int64_t>& singletonRows, Vec<int64_t>& singletonCols,
+                      Vec<int64_t>& emptyCols );
 
-   const Vec<int>&
+   const Vec<int64_t>&
    getRowSizes() const
    {
       return rowsize;
    }
 
-   Vec<int>&
+   Vec<int64_t>&
    getRowSizes()
    {
       return rowsize;
    }
 
-   const Vec<int>&
+   const Vec<int64_t>&
    getColSizes() const
    {
       return colsize;
    }
 
-   Vec<int>&
+   Vec<int64_t>&
    getColSizes()
    {
       return colsize;
@@ -436,8 +436,8 @@ class ConstraintMatrix
    template <typename CoeffChanged>
    void
    changeCoefficients( const MatrixBuffer<REAL>& matrixBuffer,
-                       Vec<int>& singletonRows, Vec<int>& singletonCols,
-                       Vec<int>& emptyCols, Vec<RowActivity<REAL>>& activities,
+                       Vec<int64_t>& singletonRows, Vec<int64_t>& singletonCols,
+                       Vec<int64_t>& emptyCols, Vec<RowActivity<REAL>>& activities,
                        CoeffChanged&& coeffChanged )
    {
       if( matrixBuffer.empty() )
@@ -452,9 +452,9 @@ class ConstraintMatrix
 
              while( iter != matrixBuffer.end() )
              {
-                int row = iter->row;
+                int64_t row = iter->row;
 
-                int newsize = cons_matrix.changeRowInplace(
+                int64_t newsize = cons_matrix.changeRowInplace(
                     row,
                     [&]() {
                        return iter != matrixBuffer.end() && iter->row == row;
@@ -493,9 +493,9 @@ class ConstraintMatrix
 
              while( iter != matrixBuffer.end() )
              {
-                int col = iter->col;
+                int64_t col = iter->col;
 
-                int newsize = cons_matrix_transp.changeRowInplace(
+                int64_t newsize = cons_matrix_transp.changeRowInplace(
                     col,
                     [&]() {
                        return iter != matrixBuffer.end() && iter->col == col;
@@ -527,15 +527,15 @@ class ConstraintMatrix
    /// get the index of the column in the sparse array of row coefficients
    template <bool transpose = false>
    int
-   getSparseIndex( int col, int row ) const
+   getSparseIndex( int64_t col, int64_t row ) const
    {
       if( !transpose )
       {
          auto rowCoef = getRowCoefficients( row );
-         const int* indices = rowCoef.getIndices();
-         const int len = rowCoef.getLength();
+         const int64_t* indices = rowCoef.getIndices();
+         const int64_t len = rowCoef.getLength();
 
-         int index = std::lower_bound( indices, indices + len, col ) - indices;
+         int64_t index = std::lower_bound( indices, indices + len, col ) - indices;
          if( index != len && indices[index] == col )
             return index;
          return -1;
@@ -543,10 +543,10 @@ class ConstraintMatrix
       else
       {
          auto colCoef = getColumnCoefficients( col );
-         const int* indices = colCoef.getIndices();
-         const int len = colCoef.getLength();
+         const int64_t* indices = colCoef.getIndices();
+         const int64_t len = colCoef.getLength();
 
-         int index = std::lower_bound( indices, indices + len, row ) - indices;
+         int64_t index = std::lower_bound( indices, indices + len, row ) - indices;
          if( index != len && indices[index] == row )
             return index;
          return -1;
@@ -558,17 +558,17 @@ class ConstraintMatrix
    /// sparsity condition is not verified, returns true if the condition is
    /// verified on all relevantRows
    bool
-   checkAggregationSparsityCondition( int col,
+   checkAggregationSparsityCondition( int64_t col,
                                       const SparseVectorView<REAL>& equalityLHS,
-                                      int maxfillin, int maxshiftperrow,
-                                      Vec<int>& indbuffer );
+                                      int64_t maxfillin, int64_t maxshiftperrow,
+                                      Vec<int64_t>& indbuffer );
 
    int
-   sparsify( const Num<REAL>& num, int eqrow, const REAL& scale, int targetrow,
-             Vec<int>& intbuffer, Vec<REAL>& valbuffer,
-             const VariableDomains<REAL>& domains, Vec<int>& changedActivities,
-             Vec<RowActivity<REAL>>& activities, Vec<int>& singletonRows,
-             Vec<int>& singletonCols, Vec<int>& emptyCols, int presolveround );
+   sparsify( const Num<REAL>& num, int64_t eqrow, const REAL& scale, int64_t targetrow,
+             Vec<int64_t>& intbuffer, Vec<REAL>& valbuffer,
+             const VariableDomains<REAL>& domains, Vec<int64_t>& changedActivities,
+             Vec<RowActivity<REAL>>& activities, Vec<int64_t>& singletonRows,
+             Vec<int64_t>& singletonCols, Vec<int64_t>& emptyCols, int64_t presolveround );
 
    /// perform the substitution of a column using an equality, and updates
    /// the sides
@@ -578,12 +578,12 @@ class ConstraintMatrix
    /// @param equalityRHS the left hand side of the equality such that sum{
    /// a_j*x_i } = equalityRHS
    void
-   aggregate( const Num<REAL>& num, int col, SparseVectorView<REAL> equalityLHS,
+   aggregate( const Num<REAL>& num, int64_t col, SparseVectorView<REAL> equalityLHS,
               REAL equalityRHS, const VariableDomains<REAL>& domains,
-              Vec<int>& indbuffer, Vec<REAL>& valbuffer,
-              Vec<Triplet<REAL>>& tripletbuffer, Vec<int>& changedActivities,
-              Vec<RowActivity<REAL>>& activities, Vec<int>& singletonRows,
-              Vec<int>& singletonCols, Vec<int>& emptyCols, int presolveround );
+              Vec<int64_t>& indbuffer, Vec<REAL>& valbuffer,
+              Vec<Triplet<REAL>>& tripletbuffer, Vec<int64_t>& changedActivities,
+              Vec<RowActivity<REAL>>& activities, Vec<int64_t>& singletonRows,
+              Vec<int64_t>& singletonCols, Vec<int64_t>& emptyCols, int64_t presolveround );
 
    const SparseStorage<REAL>&
    getMatrixTranspose() const
@@ -645,11 +645,11 @@ class ConstraintMatrix
 
    /// additional vector storing the number of non-zeros
    /// within each row of the constraint matrix
-   Vec<int> rowsize;
+   Vec<int64_t> rowsize;
 
    /// additional vector storing the number of non-zeros
    /// within each column of the constraint matrix
-   Vec<int> colsize;
+   Vec<int64_t> colsize;
 };
 
 #ifdef PAPILO_USE_EXTERN_TEMPLATES
@@ -659,10 +659,10 @@ extern template class ConstraintMatrix<Rational>;
 #endif
 
 template <typename REAL>
-std::pair<Vec<int>, Vec<int>>
+std::pair<Vec<int64_t>, Vec<int64_t>>
 ConstraintMatrix<REAL>::compress( bool full )
 {
-   std::pair<Vec<int>, Vec<int>> mappings;
+   std::pair<Vec<int64_t>, Vec<int64_t>> mappings;
 
    tbb::parallel_invoke(
        [this, &mappings, full]() {
@@ -705,49 +705,49 @@ ConstraintMatrix<REAL>::compress( bool full )
 
 template <typename REAL>
 void
-ConstraintMatrix<REAL>::deleteRowsAndCols( Vec<int>& deletedRows,
-                                           Vec<int>& deletedCols,
+ConstraintMatrix<REAL>::deleteRowsAndCols( Vec<int64_t>& deletedRows,
+                                           Vec<int64_t>& deletedCols,
                                            Vec<RowActivity<REAL>>& activities,
-                                           Vec<int>& singletonRows,
-                                           Vec<int>& singletonCols,
-                                           Vec<int>& emptyCols )
+                                           Vec<int64_t>& singletonRows,
+                                           Vec<int64_t>& singletonCols,
+                                           Vec<int64_t>& emptyCols )
 {
    if( deletedRows.empty() && deletedCols.empty() )
       return;
 
    // CSR storage
-   int* rowcols = cons_matrix.getColumns();
+   int64_t* rowcols = cons_matrix.getColumns();
    IndexRange* rowranges = cons_matrix.getRowRanges();
    REAL* rowvalues = cons_matrix.getValues();
 
    // CSC storage
-   int* colrows = cons_matrix_transp.getColumns();
+   int64_t* colrows = cons_matrix_transp.getColumns();
    IndexRange* colranges = cons_matrix_transp.getRowRanges();
    REAL* colvalues = cons_matrix_transp.getValues();
 
    tbb::parallel_invoke(
        [this, &deletedRows]() {
-          for( int row : deletedRows )
+          for( int64_t row : deletedRows )
           {
              cons_matrix.getNnz() -= rowsize[row];
              rowsize[row] = -1;
           }
        },
        [this, &deletedCols]() {
-          for( int col : deletedCols )
+          for( int64_t col : deletedCols )
              colsize[col] = -1;
        } );
 
    // delete rows from row storage and update colsizes
    tbb::parallel_invoke(
        [this, &deletedRows, rowranges, rowcols, &activities]() {
-          for( int row : deletedRows )
+          for( int64_t row : deletedRows )
           {
              assert( flags[row].test( RowFlag::kRedundant ) );
 
-             for( int i = rowranges[row].start; i != rowranges[row].end; ++i )
+             for( int64_t i = rowranges[row].start; i != rowranges[row].end; ++i )
              {
-                int col = rowcols[i];
+                int64_t col = rowcols[i];
                 if( colsize[col] == -1 )
                    continue;
 
@@ -767,11 +767,11 @@ ConstraintMatrix<REAL>::deleteRowsAndCols( Vec<int>& deletedRows,
        },
        // delete cols from col storage and update rowsizes
        [this, &deletedCols, colranges, colrows] {
-          for( int col : deletedCols )
+          for( int64_t col : deletedCols )
           {
-             for( int i = colranges[col].start; i != colranges[col].end; ++i )
+             for( int64_t i = colranges[col].start; i != colranges[col].end; ++i )
              {
-                int row = colrows[i];
+                int64_t row = colrows[i];
 
                 if( rowsize[row] == -1 )
                    continue;
@@ -787,7 +787,7 @@ ConstraintMatrix<REAL>::deleteRowsAndCols( Vec<int>& deletedRows,
 
    tbb::parallel_invoke(
        [this, colranges, &singletonCols, &emptyCols, colrows, colvalues]() {
-          for( int col = 0; col != getNCols(); ++col )
+          for( int64_t col = 0; col != getNCols(); ++col )
           {
              // if the size did not change, skip column
              if( colsize[col] == -1 ||
@@ -807,12 +807,12 @@ ConstraintMatrix<REAL>::deleteRowsAndCols( Vec<int>& deletedRows,
              default:
              {
                 // now move contents of column to occupy free spaces
-                int j = 0;
+                int64_t j = 0;
 
-                for( int i = colranges[col].start; i != colranges[col].end;
+                for( int64_t i = colranges[col].start; i != colranges[col].end;
                      ++i )
                 {
-                   int row = colrows[i];
+                   int64_t row = colrows[i];
 
                    if( rowsize[row] == -1 )
                       ++j;
@@ -832,7 +832,7 @@ ConstraintMatrix<REAL>::deleteRowsAndCols( Vec<int>& deletedRows,
           }
        },
        [this, rowranges, &singletonRows, &activities, rowcols, rowvalues]() {
-          for( int row = 0; row != getNRows(); ++row )
+          for( int64_t row = 0; row != getNRows(); ++row )
           {
              // if the size did not change, skip row
              if( rowsize[row] == -1 ||
@@ -851,11 +851,11 @@ ConstraintMatrix<REAL>::deleteRowsAndCols( Vec<int>& deletedRows,
              }
 
              // now move contents of row to occupy free spaces
-             int j = 0;
+             int64_t j = 0;
 
-             for( int i = rowranges[row].start; i != rowranges[row].end; ++i )
+             for( int64_t i = rowranges[row].start; i != rowranges[row].end; ++i )
              {
-                int col = rowcols[i];
+                int64_t col = rowcols[i];
 
                 if( colsize[col] == -1 )
                    ++j;
@@ -884,32 +884,32 @@ ConstraintMatrix<REAL>::deleteRowsAndCols( Vec<int>& deletedRows,
 template <typename REAL>
 bool
 ConstraintMatrix<REAL>::checkAggregationSparsityCondition(
-    int col, const SparseVectorView<REAL>& equalityLHS, int maxfillin,
-    int maxshiftperrow, Vec<int>& indbuffer )
+    int64_t col, const SparseVectorView<REAL>& equalityLHS, int64_t maxfillin,
+    int64_t maxshiftperrow, Vec<int64_t>& indbuffer )
 {
-   const int* indices = equalityLHS.getIndices();
-   const int len = equalityLHS.getLength();
+   const int64_t* indices = equalityLHS.getIndices();
+   const int64_t len = equalityLHS.getLength();
 
    const auto& freecolcoef = getColumnCoefficients( col );
-   const int* freecolindices = freecolcoef.getIndices();
-   const int length = freecolcoef.getLength();
+   const int64_t* freecolindices = freecolcoef.getIndices();
+   const int64_t length = freecolcoef.getLength();
 
    auto rowranges = cons_matrix.getRowRanges();
    auto colranges = cons_matrix_transp.getRowRanges();
 
-   int totalfillin = 0;
+   int64_t totalfillin = 0;
    bool eqinmatrix = false;
    bool shift = true;
 
    indbuffer.clear();
    indbuffer.reserve( std::max( length, len ) );
 
-   for( int k = 0; k < length; ++k )
+   for( int64_t k = 0; k < length; ++k )
    {
-      int row = freecolindices[k];
+      int64_t row = freecolindices[k];
       auto currentrow = getRowCoefficients( row );
-      const int* rowindices = currentrow.getIndices();
-      const int currentrowlen = currentrow.getLength();
+      const int64_t* rowindices = currentrow.getIndices();
+      const int64_t currentrowlen = currentrow.getLength();
 
       if( rowindices == indices )
       {
@@ -919,9 +919,9 @@ ConstraintMatrix<REAL>::checkAggregationSparsityCondition(
          continue;
       }
 
-      int i = 0;
-      int j = 0;
-      int fillin = -1;
+      int64_t i = 0;
+      int64_t j = 0;
+      int64_t fillin = -1;
 
       while( i < len && j < currentrowlen )
       {
@@ -944,7 +944,7 @@ ConstraintMatrix<REAL>::checkAggregationSparsityCondition(
       fillin += ( len - i );
       totalfillin += fillin;
 
-      int sparespace = rowranges[row + 1].start - rowranges[row].end;
+      int64_t sparespace = rowranges[row + 1].start - rowranges[row].end;
 
       if( sparespace < fillin )
          shift = true;
@@ -968,9 +968,9 @@ ConstraintMatrix<REAL>::checkAggregationSparsityCondition(
    indbuffer.clear();
    shift = false;
 
-   for( int k = 0; k < len; ++k )
+   for( int64_t k = 0; k < len; ++k )
    {
-      int currentcolind = indices[k];
+      int64_t currentcolind = indices[k];
       if( currentcolind == col )
       {
          indbuffer.push_back( 0 );
@@ -978,12 +978,12 @@ ConstraintMatrix<REAL>::checkAggregationSparsityCondition(
       }
 
       auto currentcol = getColumnCoefficients( currentcolind );
-      const int* colindices = currentcol.getIndices();
-      const int currentcollen = currentcol.getLength();
+      const int64_t* colindices = currentcol.getIndices();
+      const int64_t currentcollen = currentcol.getLength();
 
-      int i = 0;
-      int j = 0;
-      int fillin = eqinmatrix ? -1 : 0;
+      int64_t i = 0;
+      int64_t j = 0;
+      int64_t fillin = eqinmatrix ? -1 : 0;
 
       while( i < length && j < currentcollen )
       {
@@ -1005,7 +1005,7 @@ ConstraintMatrix<REAL>::checkAggregationSparsityCondition(
 
       fillin += ( length - i );
 
-      int sparespace =
+      int64_t sparespace =
           colranges[currentcolind + 1].start - colranges[currentcolind].end;
 
       if( sparespace < fillin )
@@ -1028,25 +1028,25 @@ ConstraintMatrix<REAL>::checkAggregationSparsityCondition(
 template <typename REAL>
 int
 ConstraintMatrix<REAL>::sparsify(
-    const Num<REAL>& num, int eqrow, const REAL& scale, int targetrow,
-    Vec<int>& intbuffer, Vec<REAL>& valbuffer,
-    const VariableDomains<REAL>& domains, Vec<int>& changedActivities,
-    Vec<RowActivity<REAL>>& activities, Vec<int>& singletonRows,
-    Vec<int>& singletonCols, Vec<int>& emptyCols, int presolveround )
+    const Num<REAL>& num, int64_t eqrow, const REAL& scale, int64_t targetrow,
+    Vec<int64_t>& intbuffer, Vec<REAL>& valbuffer,
+    const VariableDomains<REAL>& domains, Vec<int64_t>& changedActivities,
+    Vec<RowActivity<REAL>>& activities, Vec<int64_t>& singletonRows,
+    Vec<int64_t>& singletonCols, Vec<int64_t>& emptyCols, int64_t presolveround )
 {
-   int ncancel = 0;
-   int fillincol = -1;
+   int64_t ncancel = 0;
+   int64_t fillincol = -1;
    REAL fillinval = 0;
    IndexRange* colranges = cons_matrix_transp.getRowRanges();
 
    const IndexRange& eqrange = cons_matrix.getRowRanges()[eqrow];
    IndexRange& targetrange = cons_matrix.getRowRanges()[targetrow];
 
-   int* rowcols = cons_matrix.getColumns();
+   int64_t* rowcols = cons_matrix.getColumns();
    REAL* rowvals = cons_matrix.getValues();
 
-   int j = eqrange.start;
-   int k = targetrange.start;
+   int64_t j = eqrange.start;
+   int64_t k = targetrange.start;
 
    while( j != eqrange.end && k != targetrange.end )
    {
@@ -1082,7 +1082,7 @@ ConstraintMatrix<REAL>::sparsify(
       }
    }
 
-   int remainingfillin = eqrange.end - j;
+   int64_t remainingfillin = eqrange.end - j;
 
    if( remainingfillin != 0 )
    {
@@ -1104,7 +1104,7 @@ ConstraintMatrix<REAL>::sparsify(
       return 0;
 
    REAL* colvals = cons_matrix_transp.getValues();
-   int* colrows = cons_matrix_transp.getColumns();
+   int64_t* colrows = cons_matrix_transp.getColumns();
 
    // change coefficients for column where fillin occurs (we allow at most one
    // such column, otherwise we return from this function before we reach this
@@ -1117,11 +1117,11 @@ ConstraintMatrix<REAL>::sparsify(
 
       colsize[fillincol] = cons_matrix_transp.changeRow(
           fillincol, 0, 1,
-          [&]( int i ) {
+          [&]( int64_t i ) {
              assert( i == 0 );
              return targetrow;
           },
-          [&]( int i ) {
+          [&]( int64_t i ) {
              assert( i == 0 );
              return fillinval;
           },
@@ -1140,7 +1140,7 @@ ConstraintMatrix<REAL>::sparsify(
    {
       if( rowcols[j] == rowcols[k] )
       {
-         int col = rowcols[k];
+         int64_t col = rowcols[k];
          assert( col != fillincol );
 
          REAL newval = rowvals[k] + scale * rowvals[j];
@@ -1161,8 +1161,8 @@ ConstraintMatrix<REAL>::sparsify(
             newval = 0;
          }
 
-         int count = 0;
-         int newsize = cons_matrix_transp.changeRowInplace(
+         int64_t count = 0;
+         int64_t newsize = cons_matrix_transp.changeRowInplace(
              col, [&]() { return ( count++ ) == 0; },
              [&]() {
                 assert( count == 1 );
@@ -1207,7 +1207,7 @@ ConstraintMatrix<REAL>::sparsify(
    }
 
    // finally update the row
-   auto updateActivity = [&]( int row, int col, REAL oldval, REAL newval ) {
+   auto updateActivity = [&]( int64_t row, int64_t col, REAL oldval, REAL newval ) {
       auto activityChange = [row, presolveround, &changedActivities](
                                 ActivityChange actChange,
                                 RowActivity<REAL>& activity ) {
@@ -1228,10 +1228,10 @@ ConstraintMatrix<REAL>::sparsify(
           domains.flags[col], oldval, newval, activities[row], activityChange );
    };
 
-   int newsize = cons_matrix.changeRow(
+   int64_t newsize = cons_matrix.changeRow(
        targetrow, eqrange.start, eqrange.end,
-       [&]( int i ) { return rowcols[i]; },
-       [&]( int i ) { return scale * rowvals[i]; },
+       [&]( int64_t i ) { return rowcols[i]; },
+       [&]( int64_t i ) { return scale * rowvals[i]; },
        [&]( const REAL& a, const REAL& b ) {
           REAL val = a + b;
           if( num.isZero( val ) )
@@ -1261,20 +1261,20 @@ ConstraintMatrix<REAL>::sparsify(
 template <typename REAL>
 void
 ConstraintMatrix<REAL>::aggregate(
-    const Num<REAL>& num, int col, SparseVectorView<REAL> equalityLHS,
-    REAL equalityRHS, const VariableDomains<REAL>& domains, Vec<int>& indbuffer,
+    const Num<REAL>& num, int64_t col, SparseVectorView<REAL> equalityLHS,
+    REAL equalityRHS, const VariableDomains<REAL>& domains, Vec<int64_t>& indbuffer,
     Vec<REAL>& valbuffer, Vec<Triplet<REAL>>& tripletbuffer,
-    Vec<int>& changedActivities, Vec<RowActivity<REAL>>& activities,
-    Vec<int>& singletonRows, Vec<int>& singletonCols, Vec<int>& emptyCols,
-    int presolveround )
+    Vec<int64_t>& changedActivities, Vec<RowActivity<REAL>>& activities,
+    Vec<int64_t>& singletonRows, Vec<int64_t>& singletonCols, Vec<int64_t>& emptyCols,
+    int64_t presolveround )
 {
-   const int equalitylen = equalityLHS.getLength();
+   const int64_t equalitylen = equalityLHS.getLength();
    const REAL* equalityvalues = equalityLHS.getValues();
-   const int* equalityindices = equalityLHS.getIndices();
+   const int64_t* equalityindices = equalityLHS.getIndices();
 
    assert( std::is_sorted( equalityindices, equalityindices + equalitylen ) );
 
-   int freeColPos;
+   int64_t freeColPos;
    for( freeColPos = 0; freeColPos != equalitylen; ++freeColPos )
    {
       if( equalityindices[freeColPos] == col )
@@ -1289,7 +1289,7 @@ ConstraintMatrix<REAL>::aggregate(
 
    auto updateActivity = [presolveround, &changedActivities, &domains,
                           &activities, &tripletbuffer](
-                             int row, int col, REAL oldval, REAL newval ) {
+                             int64_t row, int64_t col, REAL oldval, REAL newval ) {
       if( oldval == newval )
          return;
 
@@ -1326,13 +1326,13 @@ ConstraintMatrix<REAL>::aggregate(
 
    const auto& freecol = getColumnCoefficients( col );
    const REAL* freecolcoef = freecol.getValues();
-   const int* freecolindices = freecol.getIndices();
-   const int freecollength = freecol.getLength();
+   const int64_t* freecolindices = freecol.getIndices();
+   const int64_t freecollength = freecol.getLength();
 
    // make the changes in the matrix and update the constraints' sides
-   for( int i = 0; i < freecollength; ++i )
+   for( int64_t i = 0; i < freecollength; ++i )
    {
-      int row = freecolindices[i];
+      int64_t row = freecolindices[i];
 
       assert( flags[row].test( RowFlag::kRedundant ) ||
               ( !flags[row].test( RowFlag::kEquation ) &&
@@ -1348,7 +1348,7 @@ ConstraintMatrix<REAL>::aggregate(
       if( cons_matrix.getColumns() + cons_matrix.rowranges[row].start ==
           equalityindices )
       {
-         for( int k = 0; k < equalitylen; ++k )
+         for( int64_t k = 0; k < equalitylen; ++k )
             tripletbuffer.emplace_back( equalityindices[k], row, 0 );
 
          flags[row].set( RowFlag::kRedundant );
@@ -1364,10 +1364,10 @@ ConstraintMatrix<REAL>::aggregate(
 
       REAL eqscale = eqbasescale * freecolcoef[i];
 
-      int newsize = cons_matrix.changeRow(
-          row, int{ 0 }, equalitylen,
-          [&]( int k ) { return equalityindices[k]; },
-          [&]( int k ) {
+      int64_t newsize = cons_matrix.changeRow(
+          row, int64_t{ 0 }, equalitylen,
+          [&]( int64_t k ) { return equalityindices[k]; },
+          [&]( int64_t k ) {
              return k == freeColPos ? REAL( -freecolcoef[i] )
                                     : REAL( equalityvalues[k] * eqscale );
           },
@@ -1391,7 +1391,7 @@ ConstraintMatrix<REAL>::aggregate(
       assert(
           std::all_of( getRowCoefficients( row ).getIndices(),
                        getRowCoefficients( row ).getIndices() + rowsize[row],
-                       [&]( int rowcol ) { return rowcol != col; } ) );
+                       [&]( int64_t rowcol ) { return rowcol != col; } ) );
 
       // change the bounds
       if( equalityRHS != 0 )
@@ -1422,11 +1422,11 @@ ConstraintMatrix<REAL>::aggregate(
    {
       pdqsort( tripletbuffer.begin(), tripletbuffer.end() );
 
-      auto handleCol = [&]( int col, int start, int end ) {
-         int newsize = cons_matrix_transp.changeRow(
+      auto handleCol = [&]( int64_t col, int64_t start, int64_t end ) {
+         int64_t newsize = cons_matrix_transp.changeRow(
              col, start, end,
-             [&]( int k ) { return std::get<1>( tripletbuffer[k] ); },
-             [&]( int k ) { return std::get<2>( tripletbuffer[k] ); },
+             [&]( int64_t k ) { return std::get<1>( tripletbuffer[k] ); },
+             [&]( int64_t k ) { return std::get<2>( tripletbuffer[k] ); },
              []( const REAL& oldval, const REAL& newval ) { return newval; },
              []( int, int, REAL, REAL ) {}, valbuffer, indbuffer );
 
@@ -1445,10 +1445,10 @@ ConstraintMatrix<REAL>::aggregate(
          }
       };
 
-      int start = 0;
-      int currcol = std::get<0>( tripletbuffer[0] );
-      int nchgs = tripletbuffer.size();
-      for( int i = 1; i != nchgs; ++i )
+      int64_t start = 0;
+      int64_t currcol = std::get<0>( tripletbuffer[0] );
+      int64_t nchgs = tripletbuffer.size();
+      for( int64_t i = 1; i != nchgs; ++i )
       {
          if( std::get<0>( tripletbuffer[i] ) != currcol )
          {

--- a/src/papilo/core/MatrixBuffer.hpp
+++ b/src/papilo/core/MatrixBuffer.hpp
@@ -39,13 +39,13 @@ template <typename REAL>
 struct MatrixEntry
 {
    REAL val;
-   int row;
-   int col;
+   int64_t row;
+   int64_t col;
 
    struct TreeHook
    {
-      int left;
-      int right;
+      int64_t left;
+      int64_t right;
    };
 
    TreeHook row_major;
@@ -53,7 +53,7 @@ struct MatrixEntry
 
    MatrixEntry() {}
 
-   MatrixEntry( int row, int col, const REAL& val )
+   MatrixEntry( int64_t row, int64_t col, const REAL& val )
        : val( val ), row( row ), col( col )
    {
       row_major.left = 0;
@@ -73,7 +73,7 @@ struct MatrixBuffer
 {
    template <bool RowMajor>
    int
-   splay( int n, int t )
+   splay( int64_t n, int64_t t )
    {
       using Node = GetNodeProperty<RowMajor>;
 
@@ -82,15 +82,15 @@ struct MatrixBuffer
 
       assert( t != 0 );
 
-      int l = 0;
-      int r = 0;
-      int y;
+      int64_t l = 0;
+      int64_t r = 0;
+      int64_t y;
 
       for( ;; )
       {
          if( Node::lesser( entries[n], entries[t] ) )
          {
-            int t_left = Node::left( entries[t] );
+            int64_t t_left = Node::left( entries[t] );
             if( t_left == 0 )
                break;
             if( Node::lesser( entries[n], entries[t_left] ) )
@@ -112,7 +112,7 @@ struct MatrixBuffer
          }
          else
          {
-            int t_right = Node::right( entries[t] );
+            int64_t t_right = Node::right( entries[t] );
             if( t_right == 0 )
                break;
             if( Node::lesser( entries[t_right], entries[n] ) )
@@ -148,7 +148,7 @@ struct MatrixBuffer
 
    template <bool RowMajor>
    void
-   splay_insert( int n, int t )
+   splay_insert( int64_t n, int64_t t )
    {
       using Node = GetNodeProperty<RowMajor>;
 
@@ -171,13 +171,13 @@ struct MatrixBuffer
    /// link node n into the tree for the given storage order
    template <bool RowMajor>
    void
-   link( int n )
+   link( int64_t n )
    {
       using Node = GetNodeProperty<RowMajor>;
 
       // currnode is the pointer of the parent node
       // where n will be inserted, starting with the root pointer
-      int* currnode = &Node::root( this );
+      int64_t* currnode = &Node::root( this );
 
       // get priority of n
       uint32_t prio = Node::priority( entries[n] );
@@ -194,7 +194,7 @@ struct MatrixBuffer
             // if we found a node with a smaller priority we do
             // a top down splay to make n the root of this sub tree
             // and stop insertion here.
-            int t = splay<RowMajor>( n, *currnode );
+            int64_t t = splay<RowMajor>( n, *currnode );
 
             // make n the new root
             if( Node::lesser( entries[n], entries[t] ) )
@@ -240,9 +240,9 @@ struct MatrixBuffer
    }
 
    void
-   addEntry( int row, int col, const REAL& val )
+   addEntry( int64_t row, int64_t col, const REAL& val )
    {
-      int n = entries.size();
+      int64_t n = entries.size();
       entries.emplace_back( row, col, val );
 
       this->template link<true>( n );
@@ -251,12 +251,12 @@ struct MatrixBuffer
 
    template <bool RowMajor>
    MatrixEntry<REAL>*
-   findEntry( int row, int col )
+   findEntry( int64_t row, int64_t col )
    {
       using Node = GetNodeProperty<RowMajor>;
       MatrixEntry<REAL> entry( row, col, REAL{ 0 } );
 
-      int k = Node::root( this );
+      int64_t k = Node::root( this );
 
       while( k != 0 )
       {
@@ -276,7 +276,7 @@ struct MatrixBuffer
    }
 
    void
-   addEntrySafe( int row, int col, const REAL& val )
+   addEntrySafe( int64_t row, int64_t col, const REAL& val )
    {
       MatrixEntry<REAL>* entry = findEntry<true>( row, col );
 
@@ -295,7 +295,7 @@ struct MatrixBuffer
       stack.clear();
       stack.push_back( 0 );
 
-      int k = Node::root( this );
+      int64_t k = Node::root( this );
 
       while( k != 0 )
       {
@@ -308,14 +308,14 @@ struct MatrixBuffer
 
    template <bool RowMajor>
    const MatrixEntry<REAL>*
-   beginStart( SmallVec<int, 32>& stack, int row, int col ) const
+   beginStart( SmallVec<int, 32>& stack, int64_t row, int64_t col ) const
    {
       using Node = GetNodeProperty<RowMajor>;
 
       stack.clear();
       stack.push_back( 0 );
 
-      int k = Node::root( this );
+      int64_t k = Node::root( this );
 
       assert( row == -1 || col == -1 );
 
@@ -343,7 +343,7 @@ struct MatrixBuffer
    {
       using Node = GetNodeProperty<RowMajor>;
 
-      int k = stack.back();
+      int64_t k = stack.back();
       stack.pop_back();
 
       k = Node::right( entries[k] );
@@ -363,7 +363,7 @@ struct MatrixBuffer
    }
 
    void
-   reserve( int nnz )
+   reserve( int64_t nnz )
    {
       entries.reserve( nnz + 1 );
    }
@@ -375,7 +375,7 @@ struct MatrixBuffer
    }
 
    void
-   addBadgeEntry( int row, int col, const REAL& val )
+   addBadgeEntry( int64_t row, int64_t col, const REAL& val )
    {
       assert( badge_start >= 0 && badge_start <= entries.size() );
       entries.emplace_back( row, col, val );
@@ -394,7 +394,7 @@ struct MatrixBuffer
    {
       assert( badge_start >= 0 && badge_start <= entries.size() );
 
-      for( int i = badge_start; i != entries.size(); ++i )
+      for( int64_t i = badge_start; i != entries.size(); ++i )
       {
          this->template link<true>( i );
          this->template link<false>( i );
@@ -411,11 +411,11 @@ struct MatrixBuffer
 
    SparseStorage<REAL>
    buildCSR(
-       int nrows, int ncols,
+       int64_t nrows, int64_t ncols,
        double spareRatio = SparseStorage<REAL>::DEFAULT_SPARE_RATIO,
-       int mininterrowspace = SparseStorage<REAL>::DEFAULT_MIN_INTER_ROW_SPACE )
+       int64_t mininterrowspace = SparseStorage<REAL>::DEFAULT_MIN_INTER_ROW_SPACE )
    {
-      int nnz = getNnz();
+      int64_t nnz = getNnz();
 
       SparseStorage<REAL> csrStorage( nrows, ncols, nnz, spareRatio,
                                       mininterrowspace );
@@ -423,15 +423,15 @@ struct MatrixBuffer
       SmallVec<int, 32> stack;
 
       REAL* values = csrStorage.getValues();
-      int* columns = csrStorage.getColumns();
+      int64_t* columns = csrStorage.getColumns();
       IndexRange* rowranges = csrStorage.getRowRanges();
 
       const MatrixEntry<REAL>* it = this->begin<true>( stack );
       const MatrixEntry<REAL>* end = this->end();
 
-      int k = 0;
+      int64_t k = 0;
 
-      for( int i = 0; i != nrows; ++i )
+      for( int64_t i = 0; i != nrows; ++i )
       {
          rowranges[i].start = k;
 
@@ -449,7 +449,7 @@ struct MatrixBuffer
 
          if( k != rowranges[i].start )
          {
-            int rowsize = k - rowranges[i].start;
+            int64_t rowsize = k - rowranges[i].start;
             k += csrStorage.computeRowAlloc( rowsize ) - rowsize;
          }
       }
@@ -462,11 +462,11 @@ struct MatrixBuffer
 
    SparseStorage<REAL>
    buildCSC(
-       int nrows, int ncols,
+       int64_t nrows, int64_t ncols,
        double spareRatio = SparseStorage<REAL>::DEFAULT_SPARE_RATIO,
-       int minintercolspace = SparseStorage<REAL>::DEFAULT_MIN_INTER_ROW_SPACE )
+       int64_t minintercolspace = SparseStorage<REAL>::DEFAULT_MIN_INTER_ROW_SPACE )
    {
-      int nnz = getNnz();
+      int64_t nnz = getNnz();
 
       SparseStorage<REAL> cscStorage( ncols, nrows, nnz, spareRatio,
                                       minintercolspace );
@@ -474,15 +474,15 @@ struct MatrixBuffer
       SmallVec<int, 32> stack;
 
       REAL* values = cscStorage.getValues();
-      int* rows = cscStorage.getColumns();
+      int64_t* rows = cscStorage.getColumns();
       IndexRange* colranges = cscStorage.getRowRanges();
 
       const MatrixEntry<REAL>* it = this->begin<false>( stack );
       const MatrixEntry<REAL>* end = this->end();
 
-      int k = 0;
+      int64_t k = 0;
 
-      for( int i = 0; i != ncols; ++i )
+      for( int64_t i = 0; i != ncols; ++i )
       {
          colranges[i].start = k;
 
@@ -500,7 +500,7 @@ struct MatrixBuffer
 
          if( k != colranges[i].start )
          {
-            int colsize = k - colranges[i].start;
+            int64_t colsize = k - colranges[i].start;
             k += cscStorage.computeRowAlloc( colsize ) - colsize;
          }
       }
@@ -521,9 +521,9 @@ struct MatrixBuffer
       entries.emplace_back( -1, -1, 0 );
    }
 
-   int badge_start = -1;
-   int row_major_root;
-   int col_major_root;
+   int64_t badge_start = -1;
+   int64_t row_major_root;
+   int64_t col_major_root;
    Vec<MatrixEntry<REAL>> entries;
 };
 
@@ -546,42 +546,42 @@ struct GetNodeProperty<true>
    }
 
    template <typename REAL>
-   static int&
+   static int64_t&
    left( MatrixEntry<REAL>& e )
    {
       return e.row_major.left;
    }
 
    template <typename REAL>
-   static int&
+   static int64_t&
    right( MatrixEntry<REAL>& e )
    {
       return e.row_major.right;
    }
 
    template <typename REAL>
-   static int&
+   static int64_t&
    root( MatrixBuffer<REAL>* thisptr )
    {
       return thisptr->row_major_root;
    }
 
    template <typename REAL>
-   static const int&
+   static const int64_t&
    left( const MatrixEntry<REAL>& e )
    {
       return e.row_major.left;
    }
 
    template <typename REAL>
-   static const int&
+   static const int64_t&
    right( const MatrixEntry<REAL>& e )
    {
       return e.row_major.right;
    }
 
    template <typename REAL>
-   static const int&
+   static const int64_t&
    root( const MatrixBuffer<REAL>* thisptr )
    {
       return thisptr->row_major_root;
@@ -608,42 +608,42 @@ struct GetNodeProperty<false>
    }
 
    template <typename REAL>
-   static int&
+   static int64_t&
    left( MatrixEntry<REAL>& e )
    {
       return e.col_major.left;
    }
 
    template <typename REAL>
-   static int&
+   static int64_t&
    right( MatrixEntry<REAL>& e )
    {
       return e.col_major.right;
    }
 
    template <typename REAL>
-   static int&
+   static int64_t&
    root( MatrixBuffer<REAL>* thisptr )
    {
       return thisptr->col_major_root;
    }
 
    template <typename REAL>
-   static const int&
+   static const int64_t&
    left( const MatrixEntry<REAL>& e )
    {
       return e.col_major.left;
    }
 
    template <typename REAL>
-   static const int&
+   static const int64_t&
    right( const MatrixEntry<REAL>& e )
    {
       return e.col_major.right;
    }
 
    template <typename REAL>
-   static const int&
+   static const int64_t&
    root( const MatrixBuffer<REAL>* thisptr )
    {
       return thisptr->col_major_root;

--- a/src/papilo/core/PresolveMethod.hpp
+++ b/src/papilo/core/PresolveMethod.hpp
@@ -104,7 +104,7 @@ class PresolveMethod
    virtual ~PresolveMethod() {}
 
    virtual void
-   compress( const Vec<int>& rowmap, const Vec<int>& colmap )
+   compress( const Vec<int64_t>& rowmap, const Vec<int64_t>& colmap )
    {
    }
 
@@ -230,7 +230,7 @@ class PresolveMethod
    }
 
    bool
-   runInRound( int roundCounter )
+   runInRound( int64_t roundCounter )
    {
       assert( roundCounter < 4 );
 

--- a/src/papilo/core/ProblemBuilder.hpp
+++ b/src/papilo/core/ProblemBuilder.hpp
@@ -41,7 +41,7 @@ class ProblemBuilder
    /// If the number of columns is reduced, then the information for the removed
    /// columns is lost.
    void
-   setNumCols( int ncols )
+   setNumCols( int64_t ncols )
    {
       // allocate column information
       obj.coefficients.resize( ncols );
@@ -56,7 +56,7 @@ class ProblemBuilder
    /// If the number of rows is reduced, then the information for the removed
    /// rows is lost.
    void
-   setNumRows( int nrows )
+   setNumRows( int64_t nrows )
    {
       // allocate row information
       lhs.resize( nrows );
@@ -81,7 +81,7 @@ class ProblemBuilder
 
    /// reserve storage for the given number of non-zeros
    void
-   reserve( int nnz, int nrows, int ncols )
+   reserve( int64_t nnz, int64_t nrows, int64_t ncols )
    {
       matrix_buffer.reserve( nnz );
 
@@ -101,7 +101,7 @@ class ProblemBuilder
 
    /// change the objective coefficient of a column
    void
-   setObj( int col, REAL val )
+   setObj( int64_t col, REAL val )
    {
       obj.coefficients[col] = std::move( val );
    }
@@ -111,7 +111,7 @@ class ProblemBuilder
    setObjAll( Vec<REAL> values )
    {
       assert( values.size() == obj.coefficients.size() );
-      for( int c = 0; c < values.size(); ++c )
+      for( int64_t c = 0; c < values.size(); ++c )
          obj.coefficients[c] = std::move( values[c] );
    }
 
@@ -123,7 +123,7 @@ class ProblemBuilder
    }
 
    void
-   setColLbInf( int col, bool isInfinite )
+   setColLbInf( int64_t col, bool isInfinite )
    {
       if( isInfinite )
          domains.flags[col].set( ColFlag::kLbInf );
@@ -135,12 +135,12 @@ class ProblemBuilder
    setColLbInfAll( Vec<uint8_t> isInfinite )
    {
       assert( domains.flags.size() == isInfinite.size() );
-      for( int c = 0; c < isInfinite.size(); ++c )
+      for( int64_t c = 0; c < isInfinite.size(); ++c )
          setColLbInf( c, isInfinite[c] );
    }
 
    void
-   setColUbInf( int col, bool isInfinite )
+   setColUbInf( int64_t col, bool isInfinite )
    {
       if( isInfinite )
          domains.flags[col].set( ColFlag::kUbInf );
@@ -152,12 +152,12 @@ class ProblemBuilder
    setColUbInfAll( Vec<uint8_t> isInfinite )
    {
       assert( domains.flags.size() == isInfinite.size() );
-      for( int c = 0; c < isInfinite.size(); ++c )
+      for( int64_t c = 0; c < isInfinite.size(); ++c )
          setColUbInf( c, isInfinite[c] );
    }
 
    void
-   setColLb( int col, REAL lb )
+   setColLb( int64_t col, REAL lb )
    {
       domains.lower_bounds[col] = std::move( lb );
    }
@@ -166,12 +166,12 @@ class ProblemBuilder
    setColLbAll( Vec<REAL> lbs )
    {
       assert( lbs.size() == domains.lower_bounds.size() );
-      for( int c = 0; c < lbs.size(); ++c )
+      for( int64_t c = 0; c < lbs.size(); ++c )
          domains.lower_bounds[c] = std::move( lbs[c] );
    }
 
    void
-   setColUb( int col, REAL ub )
+   setColUb( int64_t col, REAL ub )
    {
       domains.upper_bounds[col] = std::move( ub );
    }
@@ -180,12 +180,12 @@ class ProblemBuilder
    setColUbAll( Vec<REAL> ubs )
    {
       assert( ubs.size() == domains.upper_bounds.size() );
-      for( int c = 0; c < ubs.size(); ++c )
+      for( int64_t c = 0; c < ubs.size(); ++c )
          domains.upper_bounds[c] = std::move( ubs[c] );
    }
 
    void
-   setColIntegral( int col, bool isIntegral )
+   setColIntegral( int64_t col, bool isIntegral )
    {
       if( isIntegral )
          domains.flags[col].set( ColFlag::kIntegral );
@@ -197,12 +197,12 @@ class ProblemBuilder
    setColIntegralAll( Vec<uint8_t> isIntegral )
    {
       assert( isIntegral.size() == domains.flags.size() );
-      for( int c = 0; c < isIntegral.size(); ++c )
+      for( int64_t c = 0; c < isIntegral.size(); ++c )
          setColIntegral( c, isIntegral[c] );
    }
 
    void
-   setRowLhsInf( int row, bool isInfinite )
+   setRowLhsInf( int64_t row, bool isInfinite )
    {
       if( isInfinite )
          rflags[row].set( RowFlag::kLhsInf );
@@ -214,12 +214,12 @@ class ProblemBuilder
    setRowLhsInfAll( Vec<uint8_t> isInfinite )
    {
       assert( isInfinite.size() == rflags.size() );
-      for( int r = 0; r < isInfinite.size(); ++r )
+      for( int64_t r = 0; r < isInfinite.size(); ++r )
          setRowLhsInf( r, isInfinite[r] );
    }
 
    void
-   setRowRhsInf( int row, bool isInfinite )
+   setRowRhsInf( int64_t row, bool isInfinite )
    {
       if( isInfinite )
          rflags[row].set( RowFlag::kRhsInf );
@@ -231,12 +231,12 @@ class ProblemBuilder
    setRowRhsInfAll( Vec<uint8_t> isInfinite )
    {
       assert( isInfinite.size() == rflags.size() );
-      for( int r = 0; r < isInfinite.size(); ++r )
+      for( int64_t r = 0; r < isInfinite.size(); ++r )
          setRowRhsInf( r, isInfinite[r] );
    }
 
    void
-   setRowLhs( int row, REAL lhsval )
+   setRowLhs( int64_t row, REAL lhsval )
    {
       lhs[row] = std::move( lhsval );
    }
@@ -245,12 +245,12 @@ class ProblemBuilder
    setRowLhsAll( Vec<REAL> lhsvals )
    {
       assert( lhsvals.size() == lhs.size() );
-      for( int r = 0; r < lhsvals.size(); ++r )
+      for( int64_t r = 0; r < lhsvals.size(); ++r )
          lhs[r] = std::move( lhsvals[r] );
    }
 
    void
-   setRowRhs( int row, REAL rhsval )
+   setRowRhs( int64_t row, REAL rhsval )
    {
       rhs[row] = std::move( rhsval );
    }
@@ -259,13 +259,13 @@ class ProblemBuilder
    setRowRhsAll( Vec<REAL> rhsvals )
    {
       assert( rhsvals.size() == rhs.size() );
-      for( int r = 0; r < rhsvals.size(); ++r )
+      for( int64_t r = 0; r < rhsvals.size(); ++r )
          rhs[r] = std::move( rhsvals[r] );
    }
 
    /// add a nonzero entry for the given row and column
    void
-   addEntry( int row, int col, const REAL& val )
+   addEntry( int64_t row, int64_t col, const REAL& val )
    {
       assert( val != 0 );
       matrix_buffer.addEntry( row, col, val );
@@ -282,9 +282,9 @@ class ProblemBuilder
    /// add the nonzero entries for the given row
    template <typename R>
    void
-   addRowEntries( int row, int len, const int* cols, const R* vals )
+   addRowEntries( int64_t row, int64_t len, const int64_t* cols, const R* vals )
    {
-      for( int i = 0; i != len; ++i )
+      for( int64_t i = 0; i != len; ++i )
       {
          assert( vals[i] != 0 );
          matrix_buffer.addEntry( row, cols[i], REAL{ vals[i] } );
@@ -293,7 +293,7 @@ class ProblemBuilder
 
    template <typename Str>
    void
-   setRowName( int row, Str&& name )
+   setRowName( int64_t row, Str&& name )
    {
       rownames[row] = String( name );
    }
@@ -303,13 +303,13 @@ class ProblemBuilder
    setRowNameAll( Vec<Str> names )
    {
       assert( rownames.size() == names.size() );
-      for( int r = 0; r < names.size(); ++r )
+      for( int64_t r = 0; r < names.size(); ++r )
          rownames[r] = String( names[r] );
    }
 
    template <typename Str>
    void
-   setColName( int col, Str&& name )
+   setColName( int64_t col, Str&& name )
    {
       colnames[col] = String( name );
    }
@@ -319,7 +319,7 @@ class ProblemBuilder
    setColNameAll( Vec<Str> names )
    {
       assert( colnames.size() == names.size() );
-      for( int c = 0; c < names.size(); ++c )
+      for( int64_t c = 0; c < names.size(); ++c )
          colnames[c] = String( names[c] );
    }
 
@@ -333,9 +333,9 @@ class ProblemBuilder
    /// add the nonzero entries for the given column
    template <typename R>
    void
-   addColEntries( int col, int len, const int* rows, const R* vals )
+   addColEntries( int64_t col, int64_t len, const int64_t* rows, const R* vals )
    {
-      for( int i = 0; i != len; ++i )
+      for( int64_t i = 0; i != len; ++i )
       {
          assert( vals[i] != 0 );
          matrix_buffer.addEntry( rows[i], col, REAL{ vals[i] } );
@@ -347,8 +347,8 @@ class ProblemBuilder
    {
       Problem<REAL> problem;
 
-      int nrows = lhs.size();
-      int ncols = obj.coefficients.size();
+      int64_t nrows = lhs.size();
+      int64_t ncols = obj.coefficients.size();
 
       problem.setName( std::move( probname ) );
 

--- a/src/papilo/core/Reductions.hpp
+++ b/src/papilo/core/Reductions.hpp
@@ -73,12 +73,12 @@ struct Reduction
    REAL newval;
 
    /// index of row or negative for column specific operations
-   int row;
+   int64_t row;
 
    /// index of column or negative for row specific operations
-   int col;
+   int64_t col;
 
-   Reduction( REAL newval, int row, int col )
+   Reduction( REAL newval, int64_t row, int64_t col )
        : newval( newval ), row( row ), col( col )
    {
    }
@@ -93,7 +93,7 @@ class Reductions
    {
       assert( transactions.empty() || transactions.back().end >= 0 );
 
-      const int start = static_cast<int>( reductions.size() );
+      const int64_t start = static_cast<int>( reductions.size() );
       transactions.emplace_back( start, -1 );
    }
 
@@ -102,44 +102,44 @@ class Reductions
    {
       assert( !transactions.empty() && transactions.back().end == -1 );
 
-      const int end = static_cast<int>( reductions.size() );
+      const int64_t end = static_cast<int>( reductions.size() );
       assert( end != transactions.back().start );
       transactions.back().end = end;
    }
 
    void
-   changeMatrixEntry( int row, int col, REAL newval )
+   changeMatrixEntry( int64_t row, int64_t col, REAL newval )
    {
       assert( row >= 0 && col >= 0 );
       reductions.emplace_back( newval, row, col );
    }
 
    void
-   changeRowLHS( int row, REAL newval )
+   changeRowLHS( int64_t row, REAL newval )
    {
       reductions.emplace_back( newval, row, RowReduction::LHS );
    }
 
    void
-   changeRowRHS( int row, REAL newval )
+   changeRowRHS( int64_t row, REAL newval )
    {
       reductions.emplace_back( newval, row, RowReduction::RHS );
    }
 
    void
-   changeRowLHSInf( int row )
+   changeRowLHSInf( int64_t row )
    {
       reductions.emplace_back( 0.0, row, RowReduction::LHS_INF );
    }
 
    void
-   changeRowRHSInf( int row )
+   changeRowRHSInf( int64_t row )
    {
       reductions.emplace_back( 0.0, row, RowReduction::RHS_INF );
    }
 
    void
-   markRowRedundant( int row )
+   markRowRedundant( int64_t row )
    {
       reductions.emplace_back( REAL{ 0.0 }, row, RowReduction::REDUNDANT );
    }
@@ -147,7 +147,7 @@ class Reductions
    /// lock row, i.e. modifications that come before this transaction are
    /// conflicting but not modifications that come after this transaction
    void
-   lockRow( int row )
+   lockRow( int64_t row )
    {
       // locks are only valid inside a transaction
       assert( !transactions.empty() && transactions.back().end == -1 );
@@ -162,7 +162,7 @@ class Reductions
    /// lock row with a strong lock, i.e. modifications that come before or after
    /// this transaction are conflicting
    void
-   lockRowStrong( int row )
+   lockRowStrong( int64_t row )
    {
       // locks are only valid inside a transaction
       assert( !transactions.empty() && transactions.back().end == -1 );
@@ -175,25 +175,25 @@ class Reductions
    }
 
    void
-   changeObjCoeff( int col, REAL newval )
+   changeObjCoeff( int64_t col, REAL newval )
    {
       reductions.emplace_back( newval, ColReduction::OBJECTIVE, col );
    }
 
    void
-   changeColLB( int col, REAL newval )
+   changeColLB( int64_t col, REAL newval )
    {
       reductions.emplace_back( newval, ColReduction::LOWER_BOUND, col );
    }
 
    void
-   changeColUB( int col, REAL newval )
+   changeColUB( int64_t col, REAL newval )
    {
       reductions.emplace_back( newval, ColReduction::UPPER_BOUND, col );
    }
 
    void
-   fixCol( int col, REAL val )
+   fixCol( int64_t col, REAL val )
    {
       reductions.emplace_back( val, ColReduction::FIXED, col );
    }
@@ -201,7 +201,7 @@ class Reductions
    /// lock column, i.e. modifications that come before this transaction are
    /// conflicting but not modifications that come after this transaction
    void
-   lockCol( int col )
+   lockCol( int64_t col )
    {
       assert( !transactions.empty() && transactions.back().end == -1 );
       assert( transactions.back().start + transactions.back().nlocks ==
@@ -214,7 +214,7 @@ class Reductions
    /// lock column with a strong lock, i.e. modifications that come before or
    /// after this transaction are conflicting
    void
-   lockColStrong( int col )
+   lockColStrong( int64_t col )
    {
       assert( !transactions.empty() && transactions.back().end == -1 );
       assert( transactions.back().start + transactions.back().nlocks ==
@@ -226,7 +226,7 @@ class Reductions
 
    /// lock column lower and upper bounds
    void
-   lockColBounds( int col )
+   lockColBounds( int64_t col )
    {
       assert( !transactions.empty() && transactions.back().end == -1 );
       assert( transactions.back().start + transactions.back().nlocks ==
@@ -238,7 +238,7 @@ class Reductions
 
    /// signal that a column in free and can be substituted in the matrix
    void
-   aggregateFreeCol( int col, int equalityRow )
+   aggregateFreeCol( int64_t col, int64_t equalityRow )
    {
       assert( col >= 0 && equalityRow >= 0 );
       reductions.emplace_back( static_cast<REAL>( equalityRow ),
@@ -247,7 +247,7 @@ class Reductions
 
    /// signal that a column in free and can be substituted in the matrix
    void
-   substituteColInObjective( int col, int equalityRow )
+   substituteColInObjective( int64_t col, int64_t equalityRow )
    {
       assert( col >= 0 && equalityRow >= 0 );
       reductions.emplace_back( static_cast<REAL>( equalityRow ),
@@ -256,7 +256,7 @@ class Reductions
 
    // replace col1 = factor * col2 + offset
    void
-   replaceCol( int col1, int col2, REAL factor, REAL offset )
+   replaceCol( int64_t col1, int64_t col2, REAL factor, REAL offset )
    {
       assert( col1 >= 0 && col2 >= 0 );
 
@@ -271,7 +271,7 @@ class Reductions
    /// where factor is computed by using the ratio between the two
    /// columns coefficients
    void
-   parallelCols( int col1, int col2 )
+   parallelCols( int64_t col1, int64_t col2 )
    {
       assert( col1 >= 0 && col2 >= 0 );
       reductions.emplace_back( static_cast<REAL>( col2 ),
@@ -279,18 +279,18 @@ class Reductions
    }
 
    void
-   impliedInteger( int col )
+   impliedInteger( int64_t col )
    {
       assert( col >= 0 );
       reductions.emplace_back( 0, ColReduction::IMPL_INT, col );
    }
 
    void
-   sparsify( int eq, int numrows, const std::pair<int, REAL>* sparsifiedrows )
+   sparsify( int64_t eq, int64_t numrows, const std::pair<int, REAL>* sparsifiedrows )
    {
       reductions.emplace_back( static_cast<REAL>( numrows ), eq,
                                RowReduction::SPARSIFY );
-      for( int i = 0; i != numrows; ++i )
+      for( int64_t i = 0; i != numrows; ++i )
          reductions.emplace_back( sparsifiedrows[i].second,
                                   sparsifiedrows[i].first, RowReduction::NONE );
    }
@@ -316,12 +316,12 @@ class Reductions
 
    struct Transaction
    {
-      int start;
-      int end;
-      int nlocks;
-      int naddcoeffs;
+      int64_t start;
+      int64_t end;
+      int64_t nlocks;
+      int64_t naddcoeffs;
 
-      Transaction( int start, int end )
+      Transaction( int64_t start, int64_t end )
           : start( start ), end( end ), nlocks( 0 ), naddcoeffs( 0 )
       {
       }
@@ -339,7 +339,7 @@ class Reductions
 
  public:
    Reduction<REAL>&
-   getReduction( int i )
+   getReduction( int64_t i )
    {
       return reductions[i];
    }

--- a/src/papilo/core/SingleRow.hpp
+++ b/src/papilo/core/SingleRow.hpp
@@ -66,14 +66,14 @@ struct RowActivity
 
    /// number of variables that contribute with an infinite obund to the minimal
    /// activity of this row
-   int ninfmin;
+   int64_t ninfmin;
 
    /// number of variables that contribute with an infinite obund to the maximal
    /// activity of this row
-   int ninfmax;
+   int64_t ninfmax;
 
    /// last presolving round where this activity changed
-   int lastchange;
+   int64_t lastchange;
 
    bool
    repropagate( ActivityChange actChange, RowFlags rflags )
@@ -147,7 +147,7 @@ struct RowActivity
 /// counts the locks for the given row entry
 template <typename REAL>
 void
-count_locks( const REAL& val, RowFlags rflags, int& ndownlocks, int& nuplocks )
+count_locks( const REAL& val, RowFlags rflags, int64_t& ndownlocks, int64_t& nuplocks )
 {
    assert( val != 0 );
 
@@ -172,10 +172,10 @@ count_locks( const REAL& val, RowFlags rflags, int& ndownlocks, int& nuplocks )
 /// computes activity of single row from scratch
 template <typename REAL>
 RowActivity<REAL>
-compute_row_activity( const REAL* rowvals, const int* colindices, int rowlen,
+compute_row_activity( const REAL* rowvals, const int64_t* colindices, int64_t rowlen,
                       const Vec<REAL>& lower_bounds,
                       const Vec<REAL>& upper_bounds, const Vec<ColFlags>& flags,
-                      int presolveround = -1 )
+                      int64_t presolveround = -1 )
 {
    RowActivity<REAL> activity;
 
@@ -185,9 +185,9 @@ compute_row_activity( const REAL* rowvals, const int* colindices, int rowlen,
    activity.ninfmax = 0;
    activity.lastchange = presolveround;
 
-   for( int j = 0; j < rowlen; ++j )
+   for( int64_t j = 0; j < rowlen; ++j )
    {
-      int col = colindices[j];
+      int64_t col = colindices[j];
       if( !flags[col].test( ColFlag::kUbUseless ) )
       {
          if( rowvals[j] < 0 )
@@ -315,14 +315,14 @@ update_activity_after_boundchange( const REAL& colval, BoundChange type,
 /// bound of a column
 template <typename REAL>
 void
-update_activities_remove_finite_bound( const int* colinds, const REAL* colvals,
-                                       int collen, BoundChange type,
+update_activities_remove_finite_bound( const int64_t* colinds, const REAL* colvals,
+                                       int64_t collen, BoundChange type,
                                        const REAL& oldbound,
                                        Vec<RowActivity<REAL>>& activities )
 {
    if( type == BoundChange::kLower )
    {
-      for( int i = 0; i != collen; ++i )
+      for( int64_t i = 0; i != collen; ++i )
       {
          const REAL& colval = colvals[i];
          RowActivity<REAL>& activity = activities[colinds[i]];
@@ -341,7 +341,7 @@ update_activities_remove_finite_bound( const int* colinds, const REAL* colvals,
    }
    else
    {
-      for( int i = 0; i != collen; ++i )
+      for( int64_t i = 0; i != collen; ++i )
       {
          const REAL& colval = colvals[i];
          RowActivity<REAL>& activity = activities[colinds[i]];
@@ -366,8 +366,8 @@ update_activities_remove_finite_bound( const int* colinds, const REAL* colvals,
 /// changed
 template <typename REAL, typename ACTIVITYCHANGE>
 void
-update_activities_after_boundchange( const REAL* colvals, const int* colrows,
-                                     int collen, BoundChange type,
+update_activities_after_boundchange( const REAL* colvals, const int64_t* colrows,
+                                     int64_t collen, BoundChange type,
                                      REAL oldbound, REAL newbound,
                                      bool oldbound_inf,
                                      Vec<RowActivity<REAL>>& activities,
@@ -378,7 +378,7 @@ update_activities_after_boundchange( const REAL* colvals, const int* colrows,
            ( type == BoundChange::kLower && newbound != oldbound ) ||
            ( type == BoundChange::kUpper && newbound != oldbound ) );
 
-   for( int i = 0; i < collen; ++i )
+   for( int64_t i = 0; i < collen; ++i )
    {
       RowActivity<REAL>& activity = activities[colrows[i]];
 
@@ -539,7 +539,7 @@ update_activities_after_coeffchange( REAL collb, REAL colub, ColFlags cflags,
 /// and is called to inform about column bounds that changed.
 template <typename REAL, typename BOUNDCHANGE>
 void
-propagate_row( const REAL* rowvals, const int* colindices, int rowlen,
+propagate_row( const REAL* rowvals, const int64_t* colindices, int64_t rowlen,
                const RowActivity<REAL>& activity, REAL lhs, REAL rhs,
                RowFlags rflags, const Vec<REAL>& lower_bounds,
                const Vec<REAL>& upper_bounds, const Vec<ColFlags>& domainFlags,
@@ -555,9 +555,9 @@ propagate_row( const REAL* rowvals, const int* colindices, int rowlen,
 
    if( !rflags.test( RowFlag::kRhsInf ) && activity.ninfmin <= 1 )
    {
-      for( int j = 0; j < rowlen; ++j )
+      for( int64_t j = 0; j < rowlen; ++j )
       {
-         int col = colindices[j];
+         int64_t col = colindices[j];
          REAL lb = lower_bounds[col];
          REAL ub = upper_bounds[col];
          REAL minresact = activity.min;
@@ -606,9 +606,9 @@ propagate_row( const REAL* rowvals, const int* colindices, int rowlen,
 
    if( !rflags.test( RowFlag::kLhsInf ) && activity.ninfmax <= 1 )
    {
-      for( int j = 0; j < rowlen; ++j )
+      for( int64_t j = 0; j < rowlen; ++j )
       {
-         int col = colindices[j];
+         int64_t col = colindices[j];
          REAL lb = lower_bounds[col];
          REAL ub = upper_bounds[col];
          REAL maxresact = activity.max;

--- a/src/papilo/core/SparseStorage.hpp
+++ b/src/papilo/core/SparseStorage.hpp
@@ -38,7 +38,7 @@ namespace papilo
 
 /// type definition for a non-zero entry in triplet format
 template <typename REAL>
-using Triplet = std::tuple<int, int, REAL>;
+using Triplet = std::tuple<int64_t, int64_t, REAL>;
 
 // forward declaration of constraint matrix to declare the constraint matrix a
 // friend class of SparseStorage
@@ -47,8 +47,8 @@ class ConstraintMatrix;
 
 struct IndexRange
 {
-   int start;
-   int end;
+   int64_t start;
+   int64_t end;
 
    IndexRange() : start( -1 ), end( -1 ){};
 
@@ -71,55 +71,55 @@ class SparseStorage
 
  public:
    static constexpr double DEFAULT_SPARE_RATIO = 2.0;
-   static constexpr int DEFAULT_MIN_INTER_ROW_SPACE = 4;
+   static constexpr int64_t DEFAULT_MIN_INTER_ROW_SPACE = 4;
 
    SparseStorage() = default;
-   SparseStorage( Vec<Triplet<REAL>> entries, int nRows_in, int nCols_in,
+   SparseStorage( Vec<Triplet<REAL>> entries, int64_t nRows_in, int64_t nCols_in,
                   bool sorted = false, double spareRatio = DEFAULT_SPARE_RATIO,
-                  int minInterRowSpace = DEFAULT_MIN_INTER_ROW_SPACE );
-   SparseStorage( REAL* values_in, int* rowstart_in, int* columns_in,
-                  int nRows_in, int nCols_in, int nnz_in,
+                  int64_t minInterRowSpace = DEFAULT_MIN_INTER_ROW_SPACE );
+   SparseStorage( REAL* values_in, int64_t* rowstart_in, int64_t* columns_in,
+                  int64_t nRows_in, int64_t nCols_in, int64_t nnz_in,
                   double spareRatio = DEFAULT_SPARE_RATIO,
-                  int minInterRowSpace = DEFAULT_MIN_INTER_ROW_SPACE );
-   SparseStorage( int nRows_in, int nCols_in, int nnz_in, double spareRatio,
-                  int minInterRowSpace );
+                  int64_t minInterRowSpace = DEFAULT_MIN_INTER_ROW_SPACE );
+   SparseStorage( int64_t nRows_in, int64_t nCols_in, int64_t nnz_in, double spareRatio,
+                  int64_t minInterRowSpace );
 
    SparseStorage<REAL>
    getTranspose() const;
 
-   Vec<int>
-   compress( const Vec<int>& rowsize, const Vec<int>& colsize,
+   Vec<int64_t>
+   compress( const Vec<int64_t>& rowsize, const Vec<int64_t>& colsize,
              bool full = false );
 
-   int
+   int64_t
    getNRows() const
    {
       return nRows;
    }
 
    bool
-   shiftRows( const int* rowinds, int ninds, int maxshiftperrow,
-              const Vec<int>& requiredSpareSpace );
+   shiftRows( const int64_t* rowinds, int64_t ninds, int64_t maxshiftperrow,
+              const Vec<int64_t>& requiredSpareSpace );
 
-   int
+   int64_t
    getNCols() const
    {
       return nCols;
    }
 
-   int
+   int64_t
    getNnz() const
    {
       return nnz;
    }
 
-   int&
+   int64_t&
    getNnz()
    {
       return nnz;
    }
 
-   int
+   int64_t
    getNAlloc() const
    {
       return nAlloc;
@@ -161,25 +161,25 @@ class SparseStorage
       return rowranges.data();
    }
 
-   const int*
+   const int64_t*
    getColumns() const
    {
       return columns.data();
    }
 
-   int*
+   int64_t*
    getColumns()
    {
       return columns.data();
    }
 
-   const Vec<int>&
+   const Vec<int64_t>&
    getColumnsVec() const
    {
       return columns;
    }
 
-   Vec<int>
+   Vec<int64_t>
    getRowStarts() const;
 
    // function to change existing coefficients in row. Must not be called with
@@ -187,15 +187,15 @@ class SparseStorage
    // sorted order.
    template <typename HasNext, typename GetNext, typename CoeffChanged>
    int
-   changeRowInplace( int row, HasNext&& hasNext, GetNext&& getNext,
+   changeRowInplace( int64_t row, HasNext&& hasNext, GetNext&& getNext,
                      CoeffChanged&& coeffChanged )
    {
-      int i = rowranges[row].start;
-      int j = 0;
+      int64_t i = rowranges[row].start;
+      int64_t j = 0;
 
       while( hasNext() )
       {
-         int col;
+         int64_t col;
          REAL newval;
 
          std::tie( col, newval ) = getNext();
@@ -260,9 +260,9 @@ class SparseStorage
    template <typename Iter, typename GetCol, typename GetVal,
              typename MergeVals, typename CoeffChanged>
    int
-   changeRow( int row, Iter it, Iter itend, GetCol&& getCol, GetVal&& getVal,
+   changeRow( int64_t row, Iter it, Iter itend, GetCol&& getCol, GetVal&& getVal,
               MergeVals&& mergeVals, CoeffChanged&& coeffChanged,
-              Vec<REAL>& valbuffer, Vec<int>& indbuffer )
+              Vec<REAL>& valbuffer, Vec<int64_t>& indbuffer )
    {
       auto rowmaxlen =
           rowranges[row].end - rowranges[row].start + ( itend - it );
@@ -272,11 +272,11 @@ class SparseStorage
       valbuffer.reserve( rowmaxlen );
       indbuffer.reserve( rowmaxlen );
 
-      int i = rowranges[row].start;
+      int64_t i = rowranges[row].start;
 
       while( i != rowranges[row].end && it != itend )
       {
-         int col = getCol( it );
+         int64_t col = getCol( it );
 
          if( columns[i] == col )
          {
@@ -319,7 +319,7 @@ class SparseStorage
       {
          while( it != itend )
          {
-            int col = getCol( it );
+            int64_t col = getCol( it );
             REAL newval = getVal( it );
             coeffChanged( row, col, 0.0, newval );
 
@@ -333,7 +333,7 @@ class SparseStorage
       assert( valbuffer.size() == indbuffer.size() );
       assert( std::is_sorted( indbuffer.begin(), indbuffer.end() ) );
 
-      int newsize = static_cast<int>( indbuffer.size() );
+      int64_t newsize = static_cast<int>( indbuffer.size() );
 
       assert( newsize <= rowranges[row + 1].start - rowranges[row].start );
 
@@ -342,7 +342,7 @@ class SparseStorage
       // copy over values from buffer
       std::copy_n( valbuffer.data(), newsize, &values[rowranges[row].start] );
       std::memcpy( &columns[rowranges[row].start], indbuffer.data(),
-                   sizeof( int ) * newsize );
+                   sizeof( int64_t ) * newsize );
 
       rowranges[row].end = rowranges[row].start + newsize;
 
@@ -374,12 +374,12 @@ class SparseStorage
          columns.resize( nAlloc );
       }
 
-      for( int i = 0; i != nRows + 1; ++i )
+      for( int64_t i = 0; i != nRows + 1; ++i )
          ar& rowranges[i];
 
-      for( int i = 0; i != nRows; ++i )
+      for( int64_t i = 0; i != nRows; ++i )
       {
-         for( int j = rowranges[i].start; j != rowranges[i].end; ++j )
+         for( int64_t j = rowranges[i].start; j != rowranges[i].end; ++j )
          {
             ar& values[j];
             ar& columns[j];
@@ -388,28 +388,28 @@ class SparseStorage
    }
 
    int
-   computeRowAlloc( int rowsize ) const
+   computeRowAlloc( int64_t rowsize ) const
    {
       return static_cast<int>( rowsize * spareRatio ) + minInterRowSpace;
    }
 
  private:
-   int
+   int64_t
    computeNAlloc() const
    {
-      return static_cast<int>( nnz * spareRatio ) + nRows * minInterRowSpace;
+      return static_cast<int64_t>( nnz * spareRatio ) + nRows * minInterRowSpace;
    }
 
    Vec<REAL> values;
    Vec<IndexRange> rowranges;
-   Vec<int> columns;
+   Vec<int64_t> columns;
 
-   int nRows = -1;
-   int nCols = -1;
-   int nnz = -1;
-   int nAlloc = -1;
+   int64_t nRows = -1;
+   int64_t nCols = -1;
+   int64_t nnz = -1;
+   int64_t nAlloc = -1;
    double spareRatio = 0.0;
-   int minInterRowSpace = 0;
+   int64_t minInterRowSpace = 0;
 };
 
 #ifdef PAPILO_USE_EXTERN_TEMPLATES
@@ -419,9 +419,9 @@ extern template class SparseStorage<Rational>;
 #endif
 
 template <typename REAL>
-SparseStorage<REAL>::SparseStorage( Vec<Triplet<REAL>> entries, int nRows_in,
-                                    int nCols_in, bool sorted,
-                                    double spareRatio, int minInterRowSpace )
+SparseStorage<REAL>::SparseStorage( Vec<Triplet<REAL>> entries, int64_t nRows_in,
+                                    int64_t nCols_in, bool sorted,
+                                    double spareRatio, int64_t minInterRowSpace )
     : nRows( nRows_in ), nCols( nCols_in ), spareRatio( spareRatio ),
       minInterRowSpace( minInterRowSpace )
 {
@@ -440,12 +440,12 @@ SparseStorage<REAL>::SparseStorage( Vec<Triplet<REAL>> entries, int nRows_in,
 
    rowranges[0].start = 0;
 
-   int idx = 0;
-   int current_row = 0;
+   int64_t idx = 0;
+   int64_t current_row = 0;
    for( auto entry : entries )
    {
-      int row;
-      int col;
+      int64_t row;
+      int64_t col;
       REAL value;
 
       std::tie( row, col, value ) = entry;
@@ -467,7 +467,7 @@ SparseStorage<REAL>::SparseStorage( Vec<Triplet<REAL>> entries, int nRows_in,
          rowranges[current_row + 1].start = idx;
 
          // there might be empty rows
-         for( int r = current_row + 1; r < row; r++ )
+         for( int64_t r = current_row + 1; r < row; r++ )
          {
             rowranges[r].end = idx;
             rowranges[r + 1].start = idx;
@@ -498,7 +498,7 @@ SparseStorage<REAL>::SparseStorage( Vec<Triplet<REAL>> entries, int nRows_in,
    rowranges[current_row + 1].start = idx;
 
    // there might be empty rows at the end
-   for( int r = current_row + 1; r < nRows; r++ )
+   for( int64_t r = current_row + 1; r < nRows; r++ )
    {
       rowranges[r].end = idx;
       rowranges[r + 1].start = idx;
@@ -508,8 +508,8 @@ SparseStorage<REAL>::SparseStorage( Vec<Triplet<REAL>> entries, int nRows_in,
 }
 
 template <typename REAL>
-SparseStorage<REAL>::SparseStorage( int nRows_in, int nCols_in, int nnz_in,
-                                    double spareRatio, int minInterRowSpace )
+SparseStorage<REAL>::SparseStorage( int64_t nRows_in, int64_t nCols_in, int64_t nnz_in,
+                                    double spareRatio, int64_t minInterRowSpace )
     : nRows( nRows_in ), nCols( nCols_in ), nnz( nnz_in ),
       spareRatio( spareRatio ), minInterRowSpace( minInterRowSpace )
 {
@@ -525,10 +525,10 @@ SparseStorage<REAL>::SparseStorage( int nRows_in, int nCols_in, int nnz_in,
 }
 
 template <typename REAL>
-SparseStorage<REAL>::SparseStorage( REAL* values_in, int* rowstart_in,
-                                    int* columns_in, int nRows_in, int nCols_in,
-                                    int nnz_in, double spareRatio,
-                                    int minInterRowSpace )
+SparseStorage<REAL>::SparseStorage( REAL* values_in, int64_t* rowstart_in,
+                                    int64_t* columns_in, int64_t nRows_in, int64_t nCols_in,
+                                    int64_t nnz_in, double spareRatio,
+                                    int64_t minInterRowSpace )
     : nRows( nRows_in ), nCols( nCols_in ), nnz( nnz_in ),
       spareRatio( spareRatio ), minInterRowSpace( minInterRowSpace )
 {
@@ -543,12 +543,12 @@ SparseStorage<REAL>::SparseStorage( REAL* values_in, int* rowstart_in,
    rowranges.resize( nRows + 1 );
 
    // build storage
-   int shift = 0;
-   for( int r = 0; r < nRows; r++ )
+   int64_t shift = 0;
+   for( int64_t r = 0; r < nRows; r++ )
    {
       rowranges[r].start = rowstart_in[r] + shift;
 
-      for( int j = rowstart_in[r]; j < rowstart_in[r + 1]; j++ )
+      for( int64_t j = rowstart_in[r]; j < rowstart_in[r + 1]; j++ )
       {
          if( values_in[j] != REAL{ 0.0 } )
          {
@@ -564,8 +564,8 @@ SparseStorage<REAL>::SparseStorage( REAL* values_in, int* rowstart_in,
       }
 
       rowranges[r].end = rowstart_in[r + 1] + shift;
-      const int rowsize = rowranges[r].end - rowranges[r].start;
-      const int rowalloc = computeRowAlloc( rowsize );
+      const int64_t rowsize = rowranges[r].end - rowranges[r].start;
+      const int64_t rowalloc = computeRowAlloc( rowsize );
       shift += rowalloc - rowsize;
    }
 
@@ -584,14 +584,14 @@ SparseStorage<REAL>::getTranspose() const
 
    // compute nnz of each row of At (column of A)
 
-   Vec<int> w( size_t( nCols ), 0 );
+   Vec<int64_t> w( size_t( nCols ), 0 );
 
-   for( int r = 0; r < nRows; r++ )
+   for( int64_t r = 0; r < nRows; r++ )
    {
-      const int start = rowranges[r].start;
-      const int end = rowranges[r].end;
+      const int64_t start = rowranges[r].start;
+      const int64_t end = rowranges[r].end;
 
-      for( int j = start; j < end; j++ )
+      for( int64_t j = start; j < end; j++ )
       {
          assert( values[j] != REAL{ 0.0 } );
          w[columns[j]]++;
@@ -606,10 +606,10 @@ SparseStorage<REAL>::getTranspose() const
    // set row ranges of transpose
    transpose.rowranges[0].start = 0;
 
-   for( int i = 1; i <= nCols; i++ )
+   for( int64_t i = 1; i <= nCols; i++ )
    {
-      const int oldstart = transpose.rowranges[i - 1].start;
-      const int oldend = oldstart + w[i - 1];
+      const int64_t oldstart = transpose.rowranges[i - 1].start;
+      const int64_t oldend = oldstart + w[i - 1];
       assert( oldend >= oldstart );
 
       transpose.rowranges[i - 1].end = oldend;
@@ -623,14 +623,14 @@ SparseStorage<REAL>::getTranspose() const
    transpose.rowranges[nCols].end = transpose.nAlloc;
 
    // fill values and columns arrays of transpose
-   for( int r = 0; r < nRows; r++ )
+   for( int64_t r = 0; r < nRows; r++ )
    {
-      const int start = rowranges[r].start;
-      const int end = rowranges[r].end;
+      const int64_t start = rowranges[r].start;
+      const int64_t end = rowranges[r].end;
 
-      for( int j = start; j < end; j++ )
+      for( int64_t j = start; j < end; j++ )
       {
-         const int idx = w[columns[j]];
+         const int64_t idx = w[columns[j]];
 
          assert( idx < transpose.nAlloc );
 
@@ -644,8 +644,8 @@ SparseStorage<REAL>::getTranspose() const
 }
 
 template <typename REAL>
-Vec<int>
-SparseStorage<REAL>::compress( const Vec<int>& rowsize, const Vec<int>& colsize,
+Vec<int64_t>
+SparseStorage<REAL>::compress( const Vec<int64_t>& rowsize, const Vec<int64_t>& colsize,
                                bool full )
 {
    if( full )
@@ -654,13 +654,13 @@ SparseStorage<REAL>::compress( const Vec<int>& rowsize, const Vec<int>& colsize,
       minInterRowSpace = 0;
    }
    // now create and fill storage
-   Vec<int> colsmap( static_cast<std::size_t>( nCols ) );
+   Vec<int64_t> colsmap( static_cast<std::size_t>( nCols ) );
 
    if( nCols > 0 )
    {
-      int colcount = 0;
+      int64_t colcount = 0;
 
-      for( int i = 0; i < nCols; i++ )
+      for( int64_t i = 0; i < nCols; i++ )
       {
          if( colsize[i] >= 0 )
             colsmap[i] = colcount++;
@@ -673,13 +673,13 @@ SparseStorage<REAL>::compress( const Vec<int>& rowsize, const Vec<int>& colsize,
 
    if( nRows > 0 )
    {
-      int offset = 0;
-      int rowcount = 0;
-      for( int r = 0; r < nRows; r++ )
+      int64_t offset = 0;
+      int64_t rowcount = 0;
+      for( int64_t r = 0; r < nRows; r++ )
       {
-         const int start = rowranges[r].start;
-         const int end = rowranges[r].end;
-         const int rowalloc = rowranges[r + 1].start - start;
+         const int64_t start = rowranges[r].start;
+         const int64_t end = rowranges[r].end;
+         const int64_t rowalloc = rowranges[r + 1].start - start;
 
          // empty row?
          if( rowsize[r] == -1 )
@@ -704,7 +704,7 @@ SparseStorage<REAL>::compress( const Vec<int>& rowsize, const Vec<int>& colsize,
             }
 
             offset = std::max(
-                offset + rowalloc - computeRowAlloc( end - start ), 0 );
+                offset + rowalloc - computeRowAlloc( end - start ), int64_t{0} );
 
             ++rowcount;
          }
@@ -730,12 +730,12 @@ SparseStorage<REAL>::compress( const Vec<int>& rowsize, const Vec<int>& colsize,
          columns.shrink_to_fit();
       }
 
-      for( int r = 0; r < nRows; r++ )
+      for( int64_t r = 0; r < nRows; r++ )
       {
-         const int start = rowranges[r].start;
-         const int end = rowranges[r].end;
+         const int64_t start = rowranges[r].start;
+         const int64_t end = rowranges[r].end;
 
-         for( int j = start; j < end; j++ )
+         for( int64_t j = start; j < end; j++ )
          {
             assert( columns[j] >= 0 );
             assert( columns[j] < static_cast<int>( colsmap.size() ) );
@@ -751,40 +751,40 @@ SparseStorage<REAL>::compress( const Vec<int>& rowsize, const Vec<int>& colsize,
 
 template <typename REAL>
 bool
-SparseStorage<REAL>::shiftRows( const int* rowinds, int ninds,
-                                int maxshiftperrow,
-                                const Vec<int>& requiredSpareSpace )
+SparseStorage<REAL>::shiftRows( const int64_t* rowinds, int64_t ninds,
+                                int64_t maxshiftperrow,
+                                const Vec<int64_t>& requiredSpareSpace )
 {
    assert( ninds > 0 );
    assert( rowinds != nullptr );
    assert( requiredSpareSpace.size() == ninds );
    assert( std::is_sorted( rowinds, rowinds + ninds ) );
 
-   for( int i = 0; i != ninds; ++i )
+   for( int64_t i = 0; i != ninds; ++i )
    {
-      const int row = rowinds[i];
-      int missingspace = requiredSpareSpace[i] -
+      const int64_t row = rowinds[i];
+      int64_t missingspace = requiredSpareSpace[i] -
                          ( rowranges[row + 1].start - rowranges[row].end );
       if( missingspace > 0 )
       {
-         int leftbound = i == 0 ? 0 : rowinds[i - 1] + 1;
-         int rightbound = i == ninds - 1 ? nRows : rowinds[i + 1];
+         int64_t leftbound = i == 0 ? 0 : rowinds[i - 1] + 1;
+         int64_t rightbound = i == ninds - 1 ? nRows : rowinds[i + 1];
 
-         int l = row;
-         int r = row + 1;
-         int lastshiftleft = 0;
-         int lastshiftright = 0;
-         int maxshift = maxshiftperrow;
+         int64_t l = row;
+         int64_t r = row + 1;
+         int64_t lastshiftleft = 0;
+         int64_t lastshiftright = 0;
+         int64_t maxshift = maxshiftperrow;
          while( missingspace > 0 )
          {
             if( l > leftbound && r < rightbound )
             {
-               int nspaceleft = std::min(
+               int64_t nspaceleft = std::min(
                    missingspace, rowranges[l].start - rowranges[l - 1].end );
-               int nspaceright = std::min(
+               int64_t nspaceright = std::min(
                    missingspace, rowranges[r + 1].start - rowranges[r].end );
-               int nshiftleft = rowranges[l].end - rowranges[l].start;
-               int nshiftright = rowranges[r].end - rowranges[r].start;
+               int64_t nshiftleft = rowranges[l].end - rowranges[l].start;
+               int64_t nshiftright = rowranges[r].end - rowranges[r].start;
 
                bool goleft;
                if( nshiftleft == 0 )
@@ -857,18 +857,18 @@ SparseStorage<REAL>::shiftRows( const int* rowinds, int ninds,
             } while( rowranges[l].start == rowranges[l - 1].end );
 
             REAL* valsout = &values[rowranges[l].start - lastshiftleft];
-            int* colsout = &columns[rowranges[l].start - lastshiftleft];
+            int64_t* colsout = &columns[rowranges[l].start - lastshiftleft];
 
             assert( rowranges[l - 1].end <=
                     rowranges[l].start - lastshiftleft );
 
             while( l <= row )
             {
-               int shift = &values[rowranges[l].start] - valsout;
+               int64_t shift = &values[rowranges[l].start] - valsout;
 
 #ifndef NDEBUG
                Vec<REAL> tmpvals;
-               Vec<int> tmpinds;
+               Vec<int64_t> tmpinds;
                tmpvals.insert( tmpvals.end(), &values[rowranges[l].start],
                                &values[rowranges[l].end] );
                tmpinds.insert( tmpinds.end(), &columns[rowranges[l].start],
@@ -907,18 +907,18 @@ SparseStorage<REAL>::shiftRows( const int* rowinds, int ninds,
             } while( rowranges[r].end == rowranges[r + 1].start );
 
             REAL* valsout = &values[rowranges[r].end + lastshiftright];
-            int* colsout = &columns[rowranges[r].end + lastshiftright];
+            int64_t* colsout = &columns[rowranges[r].end + lastshiftright];
 
             assert( rowranges[r + 1].start >=
                     rowranges[r].end + lastshiftright );
 
             while( r > row )
             {
-               int shift = valsout - &values[rowranges[r].end];
+               int64_t shift = valsout - &values[rowranges[r].end];
 
 #ifndef NDEBUG
                Vec<REAL> tmpvals;
-               Vec<int> tmpinds;
+               Vec<int64_t> tmpinds;
                tmpvals.insert( tmpvals.end(), &values[rowranges[r].start],
                                &values[rowranges[r].end] );
                tmpinds.insert( tmpinds.end(), &columns[rowranges[r].start],
@@ -963,13 +963,13 @@ SparseStorage<REAL>::shiftRows( const int* rowinds, int ninds,
 }
 
 template <typename REAL>
-Vec<int>
+Vec<int64_t>
 SparseStorage<REAL>::getRowStarts() const
 {
-   int size = getNRows() + 1;
-   Vec<int> colStart( size );
+   int64_t size = getNRows() + 1;
+   Vec<int64_t> colStart( size );
 
-   unsigned int i;
+   int64_t i;
    for( i = 0; i < colStart.size() - 1; ++i )
    {
       colStart[i] = rowranges[i].start;

--- a/src/papilo/core/Statistics.hpp
+++ b/src/papilo/core/Statistics.hpp
@@ -30,18 +30,18 @@ namespace papilo
 struct Statistics
 {
    double presolvetime;
-   int ntsxapplied;
-   int ntsxconflicts;
-   int nboundchgs;
-   int nsidechgs;
-   int ncoefchgs;
-   int nrounds;
-   int ndeletedcols;
-   int ndeletedrows;
+   int64_t ntsxapplied;
+   int64_t ntsxconflicts;
+   int64_t nboundchgs;
+   int64_t nsidechgs;
+   int64_t ncoefchgs;
+   int64_t nrounds;
+   int64_t ndeletedcols;
+   int64_t ndeletedrows;
 
-   Statistics( double presolvetime, int ntsxapplied, int ntsxconflicts,
-               int nboundchgs, int nsidechgs, int ncoefchgs, int nrounds,
-               int ndeletedcols, int ndeletedrows )
+   Statistics( double presolvetime, int64_t ntsxapplied, int64_t ntsxconflicts,
+               int64_t nboundchgs, int64_t nsidechgs, int64_t ncoefchgs, int64_t nrounds,
+               int64_t ndeletedcols, int64_t ndeletedrows )
        : presolvetime( presolvetime ), ntsxapplied( ntsxapplied ),
          ntsxconflicts( ntsxconflicts ), nboundchgs( nboundchgs ),
          nsidechgs( nsidechgs ), ncoefchgs( ncoefchgs ), nrounds( nrounds ),

--- a/src/papilo/core/VariableDomains.hpp
+++ b/src/papilo/core/VariableDomains.hpp
@@ -67,10 +67,10 @@ struct VariableDomains
    Vec<ColFlags> flags;
 
    void
-   compress( const Vec<int>& colmapping, bool full = false );
+   compress( const Vec<int64_t>& colmapping, bool full = false );
 
    bool
-   isBinary( int col ) const
+   isBinary( int64_t col ) const
    {
       return flags[col].test( ColFlag::kIntegral ) &&
              !flags[col].test( ColFlag::kLbUseless, ColFlag::kUbUseless,
@@ -96,7 +96,7 @@ extern template struct VariableDomains<Rational>;
 
 template <typename REAL>
 void
-VariableDomains<REAL>::compress( const Vec<int>& colmapping, bool full )
+VariableDomains<REAL>::compress( const Vec<int64_t>& colmapping, bool full )
 {
    tbb::parallel_invoke(
        [this, &colmapping, full]() {

--- a/src/papilo/interfaces/HighsInterface.hpp
+++ b/src/papilo/interfaces/HighsInterface.hpp
@@ -60,11 +60,11 @@ class HighsInterface : public SolverInterface<REAL>
    }
 
    void
-   setUp( const Problem<REAL>& problem, const Vec<int>& row_maps,
-          const Vec<int>& col_maps ) override
+   setUp( const Problem<REAL>& problem, const Vec<int64_t>& row_maps,
+          const Vec<int64_t>& col_maps ) override
    {
-      int ncols = problem.getNCols();
-      int nrows = problem.getNRows();
+      int64_t ncols = problem.getNCols();
+      int64_t nrows = problem.getNRows();
       const Vec<String>& varNames = problem.getVariableNames();
       const Vec<String>& consNames = problem.getConstraintNames();
       const VariableDomains<REAL>& domains = problem.getVariableDomains();
@@ -98,7 +98,7 @@ class HighsInterface : public SolverInterface<REAL>
       model.rowLower_.resize( nrows );
       model.rowUpper_.resize( nrows );
 
-      for( int i = 0; i != nrows; ++i )
+      for( int64_t i = 0; i != nrows; ++i )
       {
          model.rowLower_[i] = rflags[i].test( RowFlag::kLhsInf )
                                   ? -inf
@@ -113,9 +113,9 @@ class HighsInterface : public SolverInterface<REAL>
       model.Astart_.resize( ncols + 1 );
       model.Astart_[ncols] = model.nnz_;
 
-      int start = 0;
+      int64_t start = 0;
 
-      for( int i = 0; i < ncols; ++i )
+      for( int64_t i = 0; i < ncols; ++i )
       {
          assert( !domains.flags[i].test( ColFlag::kInactive ) );
 
@@ -130,13 +130,13 @@ class HighsInterface : public SolverInterface<REAL>
 
          auto colvec = consMatrix.getColumnCoefficients( i );
 
-         int collen = colvec.getLength();
-         const int* colrows = colvec.getIndices();
+         int64_t collen = colvec.getLength();
+         const int64_t* colrows = colvec.getIndices();
          const REAL* colvals = colvec.getValues();
 
          model.Astart_[i] = start;
 
-         for( int k = 0; k != collen; ++k )
+         for( int64_t k = 0; k != collen; ++k )
          {
             model.Avalue_[start + k] = double( colvals[k] );
             model.Aindex_[start + k] = double( colrows[k] );
@@ -149,12 +149,12 @@ class HighsInterface : public SolverInterface<REAL>
    }
 
    void
-   setUp( const Problem<REAL>& problem, const Vec<int>& row_maps,
-          const Vec<int>& col_maps, const Components& components,
+   setUp( const Problem<REAL>& problem, const Vec<int64_t>& row_maps,
+          const Vec<int64_t>& col_maps, const Components& components,
           const ComponentInfo& component ) override
    {
-      int ncols = problem.getNCols();
-      int nrows = problem.getNRows();
+      int64_t ncols = problem.getNCols();
+      int64_t nrows = problem.getNRows();
       const Vec<String>& varNames = problem.getVariableNames();
       const Vec<String>& consNames = problem.getConstraintNames();
       const VariableDomains<REAL>& domains = problem.getVariableDomains();
@@ -163,10 +163,10 @@ class HighsInterface : public SolverInterface<REAL>
       const auto& lhs_values = consMatrix.getLeftHandSides();
       const auto& rhs_values = consMatrix.getRightHandSides();
       const auto& rflags = problem.getRowFlags();
-      const int* rowset = components.getComponentsRows( component.componentid );
-      const int* colset = components.getComponentsCols( component.componentid );
-      int numrows = components.getComponentsNumRows( component.componentid );
-      int numcols = components.getComponentsNumCols( component.componentid );
+      const int64_t* rowset = components.getComponentsRows( component.componentid );
+      const int64_t* colset = components.getComponentsCols( component.componentid );
+      int64_t numrows = components.getComponentsNumRows( component.componentid );
+      int64_t numcols = components.getComponentsNumCols( component.componentid );
 
       HighsLp model;
 
@@ -186,9 +186,9 @@ class HighsInterface : public SolverInterface<REAL>
       model.rowLower_.resize( numrows );
       model.rowUpper_.resize( numrows );
 
-      for( int i = 0; i != numrows; ++i )
+      for( int64_t i = 0; i != numrows; ++i )
       {
-         int row = rowset[i];
+         int64_t row = rowset[i];
 
          assert( components.getRowComponentIdx( row ) == i );
 
@@ -205,11 +205,11 @@ class HighsInterface : public SolverInterface<REAL>
       model.Astart_.resize( numcols + 1 );
       model.Astart_[numcols] = model.nnz_;
 
-      int start = 0;
+      int64_t start = 0;
 
-      for( int i = 0; i != numcols; ++i )
+      for( int64_t i = 0; i != numcols; ++i )
       {
-         int col = colset[i];
+         int64_t col = colset[i];
 
          assert( components.getColComponentIdx( col ) == i );
          assert( !domains.flags[col].test( ColFlag::kInactive ) );
@@ -225,13 +225,13 @@ class HighsInterface : public SolverInterface<REAL>
 
          auto colvec = consMatrix.getColumnCoefficients( col );
 
-         int collen = colvec.getLength();
-         const int* colrows = colvec.getIndices();
+         int64_t collen = colvec.getLength();
+         const int64_t* colrows = colvec.getIndices();
          const REAL* colvals = colvec.getValues();
 
          model.Astart_[i] = start;
 
-         for( int k = 0; k != collen; ++k )
+         for( int64_t k = 0; k != collen; ++k )
          {
             model.Avalue_[start + k] = double( colvals[k] );
             model.Aindex_[start + k] =
@@ -310,8 +310,8 @@ class HighsInterface : public SolverInterface<REAL>
    getSolution( Solution<REAL>& sol ) override
    {
       const HighsSolution& highsSol = solver.getSolution();
-      int numcols = solver.getNumCols();
-      int numrows = solver.getNumRows();
+      int64_t numcols = solver.getNumCols();
+      int64_t numrows = solver.getNumRows();
 
       if( highsSol.col_value.size() != numcols ||
           highsSol.col_dual.size() != numcols ||
@@ -324,7 +324,7 @@ class HighsInterface : public SolverInterface<REAL>
 
       // get primal values
       sol.primal.resize( numcols );
-      for( int i = 0; i != numcols; ++i )
+      for( int64_t i = 0; i != numcols; ++i )
          sol.primal[i] = highsSol.col_value[i];
 
       // return if no dual requested
@@ -333,26 +333,26 @@ class HighsInterface : public SolverInterface<REAL>
 
       // get reduced costs
       sol.col_dual.resize( numcols );
-      for( int i = 0; i != numcols; ++i )
+      for( int64_t i = 0; i != numcols; ++i )
          sol.col_dual[i] = REAL( highsSol.col_dual[i] );
 
       // get row duals
       sol.row_dual.resize( numrows );
-      for( int i = 0; i != numrows; ++i )
+      for( int64_t i = 0; i != numrows; ++i )
          sol.row_dual[i] = REAL( highsSol.row_dual[i] );
 
       return true;
    }
 
    bool
-   getSolution( const Components& components, int component,
+   getSolution( const Components& components, int64_t component,
                 Solution<REAL>& sol ) override
    {
       if( this->status != SolverStatus::kOptimal )
          return false;
 
-      int numcols = solver.getNumCols();
-      int numrows = solver.getNumRows();
+      int64_t numcols = solver.getNumCols();
+      int64_t numrows = solver.getNumRows();
       const HighsSolution& highsSol = solver.getSolution();
       if( highsSol.col_value.size() != numcols ||
           highsSol.col_dual.size() != numcols ||
@@ -362,19 +362,19 @@ class HighsInterface : public SolverInterface<REAL>
 
       assert( components.getComponentsNumCols( component ) == numcols );
 
-      const int* compcols = components.getComponentsCols( component );
-      for( int i = 0; i != numcols; ++i )
+      const int64_t* compcols = components.getComponentsCols( component );
+      for( int64_t i = 0; i != numcols; ++i )
          sol.primal[compcols[i]] = REAL( highsSol.col_value[i] );
 
       if( sol.type == SolutionType::kPrimal )
          return true;
 
-      for( int i = 0; i != numcols; ++i )
+      for( int64_t i = 0; i != numcols; ++i )
          sol.col_dual[compcols[i]] = REAL( highsSol.col_dual[i] );
 
-      const int* comprows = components.getComponentsRows( component );
+      const int64_t* comprows = components.getComponentsRows( component );
 
-      for( int i = 0; i != numrows; ++i )
+      for( int64_t i = 0; i != numrows; ++i )
          sol.row_dual[comprows[i]] = REAL( highsSol.row_dual[i] );
 
       return true;

--- a/src/papilo/interfaces/ScipInterface.hpp
+++ b/src/papilo/interfaces/ScipInterface.hpp
@@ -46,11 +46,11 @@ class ScipInterface : public SolverInterface<REAL>
    Vec<SCIP_VAR*> vars;
 
    SCIP_RETCODE
-   doSetUp( const Problem<REAL>& problem, const Vec<int>& origRowMap,
-            const Vec<int>& origColMap )
+   doSetUp( const Problem<REAL>& problem, const Vec<int64_t>& origRowMap,
+            const Vec<int64_t>& origColMap )
    {
-      int ncols = problem.getNCols();
-      int nrows = problem.getNRows();
+      int64_t ncols = problem.getNCols();
+      int64_t nrows = problem.getNRows();
       const Vec<String>& varNames = problem.getVariableNames();
       const Vec<String>& consNames = problem.getConstraintNames();
       const VariableDomains<REAL>& domains = problem.getVariableDomains();
@@ -64,7 +64,7 @@ class ScipInterface : public SolverInterface<REAL>
 
       vars.resize( problem.getNCols() );
 
-      for( int i = 0; i < ncols; ++i )
+      for( int64_t i = 0; i < ncols; ++i )
       {
          SCIP_VAR* var;
          assert( !domains.flags[i].test( ColFlag::kInactive ) );
@@ -102,13 +102,13 @@ class ScipInterface : public SolverInterface<REAL>
       consvars.resize( problem.getNCols() );
       consvals.resize( problem.getNCols() );
 
-      for( int i = 0; i < nrows; ++i )
+      for( int64_t i = 0; i < nrows; ++i )
       {
          SCIP_CONS* cons;
 
          auto rowvec = consMatrix.getRowCoefficients( i );
          const REAL* vals = rowvec.getValues();
-         const int* inds = rowvec.getIndices();
+         const int64_t* inds = rowvec.getIndices();
          SCIP_Real lhs = rflags[i].test( RowFlag::kLhsInf )
                              ? -SCIPinfinity( scip )
                              : SCIP_Real( lhs_values[i] );
@@ -116,7 +116,7 @@ class ScipInterface : public SolverInterface<REAL>
                              ? SCIPinfinity( scip )
                              : SCIP_Real( rhs_values[i] );
 
-         for( int k = 0; k != rowvec.getLength(); ++k )
+         for( int64_t k = 0; k != rowvec.getLength(); ++k )
          {
             consvars[k] = vars[inds[k]];
             consvals[k] = SCIP_Real( vals[k] );
@@ -136,14 +136,14 @@ class ScipInterface : public SolverInterface<REAL>
    }
 
    SCIP_RETCODE
-   doSetUp( const Problem<REAL>& problem, const Vec<int>& origRowMap,
-            const Vec<int>& origColMap, const Components& components,
+   doSetUp( const Problem<REAL>& problem, const Vec<int64_t>& origRowMap,
+            const Vec<int64_t>& origColMap, const Components& components,
             const ComponentInfo& component )
    {
-      int ncols = components.getComponentsNumCols( component.componentid );
-      int nrows = components.getComponentsNumRows( component.componentid );
-      const int* colset = components.getComponentsCols( component.componentid );
-      const int* rowset = components.getComponentsRows( component.componentid );
+      int64_t ncols = components.getComponentsNumCols( component.componentid );
+      int64_t nrows = components.getComponentsNumRows( component.componentid );
+      const int64_t* colset = components.getComponentsCols( component.componentid );
+      const int64_t* rowset = components.getComponentsRows( component.componentid );
       const Vec<String>& varNames = problem.getVariableNames();
       const Vec<String>& consNames = problem.getConstraintNames();
       const VariableDomains<REAL>& domains = problem.getVariableDomains();
@@ -157,9 +157,9 @@ class ScipInterface : public SolverInterface<REAL>
 
       vars.resize( ncols );
 
-      for( int i = 0; i < ncols; ++i )
+      for( int64_t i = 0; i < ncols; ++i )
       {
-         int col = colset[i];
+         int64_t col = colset[i];
          SCIP_VAR* var;
          assert( !domains.flags[col].test( ColFlag::kInactive ) );
 
@@ -194,14 +194,14 @@ class ScipInterface : public SolverInterface<REAL>
       consvars.resize( ncols );
       consvals.resize( ncols );
 
-      for( int i = 0; i < nrows; ++i )
+      for( int64_t i = 0; i < nrows; ++i )
       {
-         int row = rowset[i];
+         int64_t row = rowset[i];
          SCIP_CONS* cons;
 
          auto rowvec = consMatrix.getRowCoefficients( row );
          const REAL* vals = rowvec.getValues();
-         const int* inds = rowvec.getIndices();
+         const int64_t* inds = rowvec.getIndices();
          SCIP_Real lhs = rflags[row].test( RowFlag::kLhsInf )
                              ? -SCIPinfinity( scip )
                              : SCIP_Real( lhs_values[row] );
@@ -209,7 +209,7 @@ class ScipInterface : public SolverInterface<REAL>
                              ? SCIPinfinity( scip )
                              : SCIP_Real( rhs_values[row] );
 
-         for( int k = 0; k != rowvec.getLength(); ++k )
+         for( int64_t k = 0; k != rowvec.getLength(); ++k )
          {
             consvars[k] = vars[components.getColComponentIdx( inds[k] )];
             consvals[k] = SCIP_Real( vals[k] );
@@ -249,8 +249,8 @@ class ScipInterface : public SolverInterface<REAL>
    }
 
    void
-   setUp( const Problem<REAL>& prob, const Vec<int>& row_maps,
-          const Vec<int>& col_maps, const Components& components,
+   setUp( const Problem<REAL>& prob, const Vec<int64_t>& row_maps,
+          const Vec<int64_t>& col_maps, const Components& components,
           const ComponentInfo& component ) override
    {
       if( doSetUp( prob, row_maps, col_maps, components, component ) !=
@@ -318,8 +318,8 @@ class ScipInterface : public SolverInterface<REAL>
    }
 
    void
-   setUp( const Problem<REAL>& prob, const Vec<int>& row_maps,
-          const Vec<int>& col_maps ) override
+   setUp( const Problem<REAL>& prob, const Vec<int64_t>& row_maps,
+          const Vec<int64_t>& col_maps ) override
    {
       if( doSetUp( prob, row_maps, col_maps ) != SCIP_OKAY )
          this->status = SolverStatus::kError;
@@ -421,7 +421,7 @@ class ScipInterface : public SolverInterface<REAL>
    }
 
    bool
-   getSolution( const Components& components, int component,
+   getSolution( const Components& components, int64_t component,
                 Solution<REAL>& solbuffer ) override
    {
       SCIP_SOL* sol = SCIPgetBestSol( scip );
@@ -434,7 +434,7 @@ class ScipInterface : public SolverInterface<REAL>
          SCIP_SOL* finitesol;
          SCIP_Bool success;
 
-         const int* colset = components.getComponentsCols( component );
+         const int64_t* colset = components.getComponentsCols( component );
          assert( components.getComponentsNumCols( component ) == vars.size() );
 
          SCIP_CALL_ABORT(

--- a/src/papilo/interfaces/SolverInterface.hpp
+++ b/src/papilo/interfaces/SolverInterface.hpp
@@ -62,12 +62,12 @@ class SolverInterface
    SolverInterface() : status( SolverStatus::kInit ) {}
 
    virtual void
-   setUp( const Problem<REAL>& prob, const Vec<int>& row_maps,
-          const Vec<int>& col_maps ) = 0;
+   setUp( const Problem<REAL>& prob, const Vec<int64_t>& row_maps,
+          const Vec<int64_t>& col_maps ) = 0;
 
    virtual void
-   setUp( const Problem<REAL>& prob, const Vec<int>& row_maps,
-          const Vec<int>& col_maps, const Components& components,
+   setUp( const Problem<REAL>& prob, const Vec<int64_t>& row_maps,
+          const Vec<int64_t>& col_maps, const Components& components,
           const ComponentInfo& component ) = 0;
 
    virtual void
@@ -120,7 +120,7 @@ class SolverInterface
    getSolution( Solution<REAL>& sol ) = 0;
 
    virtual bool
-   getSolution( const Components& components, int component,
+   getSolution( const Components& components, int64_t component,
                 Solution<REAL>& sol ) = 0;
 
    virtual REAL

--- a/src/papilo/io/MpsParser.hpp
+++ b/src/papilo/io/MpsParser.hpp
@@ -192,9 +192,9 @@ class MpsParser
    Vec<ColFlags> col_flags;
    REAL objoffset = 0;
 
-   int nCols = 0;
-   int nRows = 0;
-   int nnz = -1;
+   int64_t nCols = 0;
+   int64_t nRows = 0;
+   int64_t nnz = -1;
 
    /// checks first word of strline and wraps it by it_begin and it_end
    parsekey
@@ -380,9 +380,9 @@ MpsParser<REAL>::parseCols( boost::iostreams::filtering_istream& file,
 
    std::string colname = "";
    std::string strline;
-   int rowidx;
-   int ncols = 0;
-   int colstart = 0;
+   int64_t rowidx;
+   int64_t ncols = 0;
+   int64_t colstart = 0;
    bool integral_cols = false;
 
    auto parsename = [&rowidx, this]( std::string name ) {
@@ -528,7 +528,7 @@ MpsParser<REAL>::parseRanges( boost::iostreams::filtering_istream& file )
       if( word_ref.empty() )
          continue;
 
-      int rowidx;
+      int64_t rowidx;
 
       auto parsename = [&rowidx, this]( std::string name ) {
          auto mit = rowname2idx.find( name );
@@ -606,7 +606,7 @@ MpsParser<REAL>::parseRhs( boost::iostreams::filtering_istream& file )
       if( word_ref.empty() )
          continue;
 
-      int rowidx;
+      int64_t rowidx;
 
       auto parsename = [&rowidx, this]( std::string name ) {
          auto mit = rowname2idx.find( name );
@@ -733,7 +733,7 @@ MpsParser<REAL>::parseBounds( boost::iostreams::filtering_istream& file )
       qi::phrase_parse( it, strline.end(), qi::lexeme[+qi::graph],
                         ascii::space );
 
-      int colidx;
+      int64_t colidx;
 
       auto parsename = [&colidx, this]( std::string name ) {
          auto mit = colname2idx.find( name );

--- a/src/papilo/io/MpsWriter.hpp
+++ b/src/papilo/io/MpsWriter.hpp
@@ -50,7 +50,7 @@ struct MpsWriter
 {
    static void
    writeProb( const std::string& filename, const Problem<REAL>& prob,
-              const Vec<int>& row_mapping, const Vec<int>& col_mapping )
+              const Vec<int64_t>& row_mapping, const Vec<int64_t>& col_mapping )
    {
       const ConstraintMatrix<REAL>& consmatrix = prob.getConstraintMatrix();
       const Vec<std::string>& consnames = prob.getConstraintNames();
@@ -85,7 +85,7 @@ struct MpsWriter
       fmt::print( out, "ROWS\n" );
       fmt::print( out, " N  OBJ\n" );
       bool hasRangedRow = false;
-      for( int i = 0; i < consmatrix.getNRows(); ++i )
+      for( int64_t i = 0; i < consmatrix.getNRows(); ++i )
       {
          // discard redundant rows when writing problem
          assert( !consmatrix.isRowRedundant( i ) );
@@ -111,15 +111,15 @@ struct MpsWriter
 
       fmt::print( out, "COLUMNS\n" );
 
-      int hasintegral = prob.getNumIntegralCols() != 0;
+      int64_t hasintegral = prob.getNumIntegralCols() != 0;
 
-      for( int integral = 0; integral <= hasintegral; ++integral )
+      for( int64_t integral = 0; integral <= hasintegral; ++integral )
       {
          if( integral )
             fmt::print( out,
                         "    MARK0000  'MARKER'                 'INTORG'\n" );
 
-         for( int i = 0; i < consmatrix.getNCols(); ++i )
+         for( int64_t i = 0; i < consmatrix.getNCols(); ++i )
          {
             if( col_flags[i].test( ColFlag::kInactive ) )
                continue;
@@ -141,13 +141,13 @@ struct MpsWriter
             SparseVectorView<REAL> column =
                 consmatrix.getColumnCoefficients( i );
 
-            const int* rowinds = column.getIndices();
+            const int64_t* rowinds = column.getIndices();
             const REAL* colvals = column.getValues();
-            int len = column.getLength();
+            int64_t len = column.getLength();
 
-            for( int j = 0; j < len; ++j )
+            for( int64_t j = 0; j < len; ++j )
             {
-               int r = rowinds[j];
+               int64_t r = rowinds[j];
 
                // discard redundant rows when writing problem
                if( consmatrix.isRowRedundant( r ) )
@@ -177,7 +177,7 @@ struct MpsWriter
                         double( REAL( -obj.offset ) ) );
       }
 
-      for( int i = 0; i < consmatrix.getNRows(); ++i )
+      for( int64_t i = 0; i < consmatrix.getNRows(); ++i )
       {
          // discard redundant rows when writing problem
          if( consmatrix.isRowRedundant( i ) )
@@ -204,7 +204,7 @@ struct MpsWriter
       if( hasRangedRow )
       {
          fmt::print( out, "RANGES\n" );
-         for( int i = 0; i < consmatrix.getNRows(); ++i )
+         for( int64_t i = 0; i < consmatrix.getNRows(); ++i )
          {
             if( row_flags[i].test( RowFlag::kLhsInf, RowFlag::kRhsInf,
                                    RowFlag::kEquation, RowFlag::kRedundant ) )
@@ -222,7 +222,7 @@ struct MpsWriter
 
       fmt::print( out, "BOUNDS\n" );
 
-      for( int i = 0; i < consmatrix.getNCols(); ++i )
+      for( int64_t i = 0; i < consmatrix.getNCols(); ++i )
       {
          if( col_flags[i].test( ColFlag::kInactive ) )
             continue;

--- a/src/papilo/io/SolParser.hpp
+++ b/src/papilo/io/SolParser.hpp
@@ -43,14 +43,14 @@ struct SolParser
 {
 
    static Solution<REAL>
-   read( std::ifstream& file, const Vec<int>& origcol_mapping,
+   read( std::ifstream& file, const Vec<int64_t>& origcol_mapping,
          const Vec<String>& colnames )
    {
       HashMap<String, int> nameToCol;
 
       for( size_t i = 0; i != origcol_mapping.size(); ++i )
       {
-         int origcol = origcol_mapping[i];
+         int64_t origcol = origcol_mapping[i];
          nameToCol.emplace( colnames[origcol], i );
       }
 

--- a/src/papilo/io/SolWriter.hpp
+++ b/src/papilo/io/SolWriter.hpp
@@ -67,7 +67,7 @@ struct SolWriter
 
       fmt::print( out, "{: <50} {: <18.15}\n", "=obj=", double( solobj ) );
 
-      for( int i = 0; i != sol.size(); ++i )
+      for( int64_t i = 0; i != sol.size(); ++i )
       {
          if( sol[i] != 0.0 )
          {

--- a/src/papilo/misc/Alloc.hpp
+++ b/src/papilo/misc/Alloc.hpp
@@ -29,7 +29,7 @@
 namespace papilo
 {
 
-template <typename T, int = 0>
+template <typename T, int64_t = 0>
 struct AllocatorTraits
 {
    using type = std::allocator<T>;

--- a/src/papilo/misc/Array.hpp
+++ b/src/papilo/misc/Array.hpp
@@ -61,13 +61,13 @@ class Array
    }
 
    T&
-   operator[]( int i )
+   operator[]( int64_t i )
    {
       return ptr[i];
    }
 
    const T&
-   operator[]( int i ) const
+   operator[]( int64_t i ) const
    {
       return ptr[i];
    }

--- a/src/papilo/misc/DependentRows.hpp
+++ b/src/papilo/misc/DependentRows.hpp
@@ -71,15 +71,15 @@ class DependentRows
    }
 
    void
-   addRow( int rowIndex, SparseVectorView<REAL> rowValues, REAL side )
+   addRow( int64_t rowIndex, SparseVectorView<REAL> rowValues, REAL side )
    {
-      int len = rowValues.getLength();
-      const int* inds = rowValues.getIndices();
+      int64_t len = rowValues.getLength();
+      const int64_t* inds = rowValues.getIndices();
       const REAL* vals = rowValues.getValues();
 
       mat.startBadge();
 
-      for( int i = 0; i != len; ++i )
+      for( int64_t i = 0; i != len; ++i )
          mat.addBadgeEntry( rowIndex, inds[i], vals[i] );
 
       if( side != 0 )
@@ -90,15 +90,15 @@ class DependentRows
 
    struct PivotCandidate
    {
-      int idx;
-      int colsize;
-      int rowsize;
+      int64_t idx;
+      int64_t colsize;
+      int64_t rowsize;
 
       bool
       operator<( const PivotCandidate& other ) const
       {
-         int trivial = colsize == 1 || rowsize == 1;
-         int othertrivial = other.colsize == 1 || other.rowsize == 1;
+         int64_t trivial = colsize == 1 || rowsize == 1;
+         int64_t othertrivial = other.colsize == 1 || other.rowsize == 1;
 
          return std::make_tuple( trivial, colsize, rowsize ) >
                 std::make_tuple( othertrivial, other.colsize, other.rowsize );
@@ -144,7 +144,7 @@ class DependentRows
          Vec<double> colmax( ncols );
          Vec<double> colmin( ncols );
 
-         for( int i = 0; i < A.size(); ++i )
+         for( int64_t i = 0; i < A.size(); ++i )
          {
             double absai = abs( A[i] );
             rowmax[indc[i] - 1] = std::max( rowmax[indc[i] - 1], absai );
@@ -157,47 +157,47 @@ class DependentRows
          }
 
          double maxrowratio = 1;
-         for( int i = 0; i < rowmax.size(); ++i )
+         for( int64_t i = 0; i < rowmax.size(); ++i )
             maxrowratio = std::max( maxrowratio, rowmax[i] / rowmin[i] );
 
          double maxcolratio = 1;
-         for( int i = 0; i < colmax.size(); ++i )
+         for( int64_t i = 0; i < colmax.size(); ++i )
             maxcolratio = std::max( maxcolratio, colmax[i] / colmin[i] );
 
          if( maxrowratio < maxcolratio )
          {
-            for( int i = 0; i < A.size(); ++i )
+            for( int64_t i = 0; i < A.size(); ++i )
                A[i] = ( A[i] / rowmax[indc[i] - 1] );
 
-            for( int i = 0; i < colmax.size(); ++i )
+            for( int64_t i = 0; i < colmax.size(); ++i )
                colmax[i] = 0;
 
-            for( int i = 0; i < A.size(); ++i )
+            for( int64_t i = 0; i < A.size(); ++i )
                colmax[indr[i] - 1] =
                    std::max( colmax[indr[i] - 1], abs( A[i] ) );
 
-            for( int i = 0; i < A.size(); ++i )
+            for( int64_t i = 0; i < A.size(); ++i )
                A[i] = ( A[i] / colmax[indr[i] - 1] );
          }
          else
          {
-            for( int i = 0; i < A.size(); ++i )
+            for( int64_t i = 0; i < A.size(); ++i )
                A[i] = ( A[i] / colmax[indr[i] - 1] );
 
-            for( int i = 0; i < rowmax.size(); ++i )
+            for( int64_t i = 0; i < rowmax.size(); ++i )
                rowmax[i] = 0;
 
-            for( int i = 0; i < A.size(); ++i )
+            for( int64_t i = 0; i < A.size(); ++i )
                rowmax[indc[i] - 1] =
                    std::max( rowmax[indc[i] - 1], abs( A[i] ) );
 
-            for( int i = 0; i < A.size(); ++i )
+            for( int64_t i = 0; i < A.size(); ++i )
                A[i] = ( A[i] / rowmax[indc[i] - 1] );
          }
       }
 
       void
-      computeDependentColumns( Vec<int>& colmapping )
+      computeDependentColumns( Vec<int64_t>& colmapping )
       {
 #ifdef PAPILO_HAVE_LUSOL
          // is passed in : int64_t nelem;
@@ -249,7 +249,7 @@ class DependentRows
 
          if( ( inform == 0 || inform == 1 ) && luparm[10] > 0 )
          {
-            for( int i = 0; i < ncols; ++i )
+            for( int64_t i = 0; i < ncols; ++i )
             {
                if( w[i] > 0 )
                   colmapping[i] = -1;
@@ -270,15 +270,15 @@ class DependentRows
 
    int64_t
    preprocessLUFac( const Message& msg, const Num<REAL>& num,
-                    LUSOL_Input& lusolInput, Vec<int>& rowmapping )
+                    LUSOL_Input& lusolInput, Vec<int64_t>& rowmapping )
    {
       SmallVec<int, 32> stack;
       SmallVec<int, 32> stack2;
 
-      Vec<int> rowsize( nrows );
-      Vec<int> colsize( ncols );
+      Vec<int64_t> rowsize( nrows );
+      Vec<int64_t> colsize( ncols );
 
-      for( int i = 1; i != mat.entries.size(); ++i )
+      for( int64_t i = 1; i != mat.entries.size(); ++i )
       {
          assert( mat.entries[i].row < nrows );
          assert( mat.entries[i].col < ncols );
@@ -288,17 +288,17 @@ class DependentRows
       }
 
 #ifndef NDEBUG
-      for( int i = 0; i != colsize.size(); ++i )
+      for( int64_t i = 0; i != colsize.size(); ++i )
       {
-         int tmpcolsize = 0;
+         int64_t tmpcolsize = 0;
          for( auto coliter = mat.template beginStart<false>( stack, -1, i );
               coliter->col == i; coliter = mat.template next<false>( stack ) )
             ++tmpcolsize;
          assert( tmpcolsize == colsize[i] );
       }
-      for( int i = 0; i != rowsize.size(); ++i )
+      for( int64_t i = 0; i != rowsize.size(); ++i )
       {
-         int tmprowsize = 0;
+         int64_t tmprowsize = 0;
          for( auto rowiter = mat.template beginStart<true>( stack, i, -1 );
               rowiter->row == i; rowiter = mat.template next<true>( stack ) )
             ++tmprowsize;
@@ -312,14 +312,14 @@ class DependentRows
 
       heap.reserve( 2 * mat.getNnz() );
 
-      for( int i = 1; i != mat.entries.size(); ++i )
+      for( int64_t i = 1; i != mat.entries.size(); ++i )
       {
          PivotCandidate p{ i, colsize[mat.entries[i].col],
                            rowsize[mat.entries[i].row] };
          heap.push( p );
       }
 
-      int nremoved = 0;
+      int64_t nremoved = 0;
       REAL minpivot = num.getFeasTol() * 1e4;
 
       while( !heap.empty() )
@@ -364,8 +364,8 @@ class DependentRows
 
          nremoved++;
 
-         int col = pivotentry->col;
-         int pivotrow = pivotentry->row;
+         int64_t col = pivotentry->col;
+         int64_t pivotrow = pivotentry->row;
          REAL pivotrowscale = -1.0 / pivotentry->val;
 
          if( !trivialpivot )
@@ -416,7 +416,7 @@ class DependentRows
                      {
                         const_cast<MatrixEntry<REAL>*>( rowentry )->val =
                             newval;
-                        int rowentryidx = ( rowentry - &mat.entries[0] );
+                        int64_t rowentryidx = ( rowentry - &mat.entries[0] );
                         assert( rowentryidx > 0 &&
                                 rowentryidx < mat.entries.size() &&
                                 rowentry == &mat.entries[rowentryidx] );
@@ -429,12 +429,12 @@ class DependentRows
                   {
                      ++colsize[rowiter->col];
                      ++rowsize[coliter->row];
-                     int rowentryidx = int( mat.entries.size() );
+                     int64_t rowentryidx = int( mat.entries.size() );
                      heap.push( PivotCandidate{ rowentryidx,
                                                 colsize[rowiter->col],
                                                 rowsize[coliter->row] } );
-                     int tmpcoliteridx = ( coliter - &mat.entries[0] );
-                     int tmprowiteridx = ( rowiter - &mat.entries[0] );
+                     int64_t tmpcoliteridx = ( coliter - &mat.entries[0] );
+                     int64_t tmprowiteridx = ( rowiter - &mat.entries[0] );
                      mat.addEntry( coliter->row, rowiter->col, delta );
                      coliter = &mat.entries[tmpcoliteridx];
                      rowiter = &mat.entries[tmprowiteridx];
@@ -477,7 +477,7 @@ class DependentRows
 
       int64_t remainingnnz = 0;
 
-      for( int i = 0; i < rowsize.size(); ++i )
+      for( int64_t i = 0; i < rowsize.size(); ++i )
       {
          if( rowsize[i] != -1 )
          {
@@ -495,7 +495,7 @@ class DependentRows
 
       nrows = rowmapping.size();
       ncols = 0;
-      for( int i = 0; i < colsize.size(); ++i )
+      for( int64_t i = 0; i < colsize.size(); ++i )
       {
          if( colsize[i] != -1 )
          {
@@ -507,7 +507,7 @@ class DependentRows
       // add data to lusol transposed
       lusolInput.setSize( ncols, nrows, remainingnnz );
 
-      for( int i = 1; i != mat.entries.size(); ++i )
+      for( int64_t i = 1; i != mat.entries.size(); ++i )
       {
          if( mat.entries[i].val == 0 )
             continue;
@@ -522,10 +522,10 @@ class DependentRows
       return remainingnnz;
    }
 
-   Vec<int>
+   Vec<int64_t>
    getDependentRows( const Message& msg, const Num<REAL>& num )
    {
-      Vec<int> rowmapping;
+      Vec<int64_t> rowmapping;
       LUSOL_Input lusolInput;
 
       if( !DependentRows<REAL>::Enabled )

--- a/src/papilo/misc/Hash.hpp
+++ b/src/papilo/misc/Hash.hpp
@@ -39,7 +39,7 @@
 namespace papilo
 {
 
-template <typename T, int TWidth = sizeof( T )>
+template <typename T, int64_t TWidth = sizeof( T )>
 struct HashHelpers;
 
 template <typename T>
@@ -52,7 +52,7 @@ struct HashHelpers<T, 4>
    }
 
    static uint32_t
-   rotate_left( uint32_t x, int n )
+   rotate_left( uint32_t x, int64_t n )
    {
       return ( x << n ) | ( x >> ( 32 - n ) );
    }
@@ -68,7 +68,7 @@ struct HashHelpers<T, 8>
    }
 
    static uint64_t
-   rotate_left( uint64_t x, int n )
+   rotate_left( uint64_t x, int64_t n )
    {
       return ( x << n ) | ( x >> ( 64 - n ) );
    }

--- a/src/papilo/misc/KktCheckHelper.hpp
+++ b/src/papilo/misc/KktCheckHelper.hpp
@@ -34,8 +34,8 @@ namespace papilo
 
 template <typename REAL>
 void
-addRow( Problem<REAL>& problem, const int row, const int length,
-        const REAL* values, const int* coeffs, const REAL lhs, const REAL rhs,
+addRow( Problem<REAL>& problem, const int64_t row, const int64_t length,
+        const REAL* values, const int64_t* coeffs, const REAL lhs, const REAL rhs,
         const bool lb_inf, const bool ub_inf )
 {
    // Assuming problem is expanded and row will be added at the preacllocated

--- a/src/papilo/misc/KktChecker.hpp
+++ b/src/papilo/misc/KktChecker.hpp
@@ -105,8 +105,8 @@ class KktState
          colUpper( problem.getVariableDomains().upper_bounds ),
          level( checker_level )
    {
-      const int nRows = problem.getNRows();
-      const int nCols = problem.getNCols();
+      const int64_t nRows = problem.getNRows();
+      const int64_t nCols = problem.getNCols();
 
       // We can have a problem with no rows and columns.
       if( nRows == 0 && nCols == 0 )
@@ -136,8 +136,8 @@ class KktState
          rowUpper( rowUpper_ ), colLower( colLower_ ), colUpper( colUpper_ ),
          level( checker_level )
    {
-      const int nRows = problem.getNRows();
-      const int nCols = problem.getNCols();
+      const int64_t nRows = problem.getNRows();
+      const int64_t nCols = problem.getNCols();
 
       // We can have a problem with no rows and columns.
       if( nRows == 0 && nCols == 0 )
@@ -167,8 +167,8 @@ class KktState
    checkPrimalBounds()
    {
       kkt_status status = kkt_status::OK;
-      int reduced_index = 0;
-      for( unsigned int col = 0; col < solSetCol.size(); col++ )
+      int64_t reduced_index = 0;
+      for( int64_t col = 0; col < solSetCol.size(); col++ )
       {
          if( !solSetCol[col] )
             continue;
@@ -195,13 +195,13 @@ class KktState
    kkt_status
    checkLength()
    {
-      const int nCols = solSetCol.size();
+      const int64_t nCols = solSetCol.size();
 
       if( colLower.size() != nCols || colUpper.size() != nCols ||
           colValues.size() != nCols || colDuals.size() != nCols )
          return kkt_status::Fail_Length;
 
-      const int nRows = solSetRow.size();
+      const int64_t nRows = solSetRow.size();
 
       if( rowLower.size() != nRows || rowUpper.size() != nRows ||
           rowValues.size() != nRows || rowDuals.size() != nRows )
@@ -220,8 +220,8 @@ class KktState
       if( status != kkt_status::OK )
          return status;
 
-      int reduced_index = 0;
-      for( int row = 0; row < solSetRow.size(); row++ )
+      int64_t reduced_index = 0;
+      for( int64_t row = 0; row < solSetRow.size(); row++ )
       {
          if( !solSetRow[row] )
             continue;
@@ -250,8 +250,8 @@ class KktState
       const Vec<REAL>& colUpper = problem.getVariableDomains().upper_bounds;
 
       // check values of z_j are dual feasible
-      int reduced_index = 0;
-      for( int col = 0; col < solSetCol.size(); col++ )
+      int64_t reduced_index = 0;
+      for( int64_t col = 0; col < solSetCol.size(); col++ )
       {
          if( !solSetCol[col] )
             continue;
@@ -287,8 +287,8 @@ class KktState
           problem.getConstraintMatrix().getRightHandSides();
 
       std::vector<int> orig_col_index( matrixRW.getNCols(), 0 );
-      int reduced_col_index = 0;
-      for( int col = 0; col < solSetCol.size(); col++ )
+      int64_t reduced_col_index = 0;
+      for( int64_t col = 0; col < solSetCol.size(); col++ )
       {
          if( !solSetCol[col] )
             continue;
@@ -298,7 +298,7 @@ class KktState
 
       assert( matrixRW.getNCols() == reduced_col_index );
 
-      for( int row = 0; row < solSetRow.size(); row++ )
+      for( int64_t row = 0; row < solSetRow.size(); row++ )
       {
          if( !solSetRow[row] )
             continue;
@@ -336,8 +336,8 @@ class KktState
    kkt_status
    checkComplementarySlackness()
    {
-      int reduced_index = 0;
-      for( int col = 0; col < solSetCol.size(); col++ )
+      int64_t reduced_index = 0;
+      for( int64_t col = 0; col < solSetCol.size(); col++ )
       {
          if( !solSetCol[col] )
             continue;
@@ -375,8 +375,8 @@ class KktState
       //    problem.getConstraintMatrix().getConstraintMatrix().getTranspose();
 
       std::vector<int> orig_row_index( matrixCW.getNCols(), 0 );
-      int reduced_row_index = 0;
-      for( int row = 0; row < solSetRow.size(); row++ )
+      int64_t reduced_row_index = 0;
+      for( int64_t row = 0; row < solSetRow.size(); row++ )
       {
          if( !solSetRow[row] )
             continue;
@@ -387,8 +387,8 @@ class KktState
       // Below is used getNCols() because matrixCW is the transpose.
       assert( matrixCW.getNCols() == reduced_row_index );
 
-      int reduced_index = 0;
-      for( int col = 0; col < solSetCol.size(); col++ )
+      int64_t reduced_index = 0;
+      for( int64_t col = 0; col < solSetCol.size(); col++ )
       {
          if( !solSetCol[col] )
             continue;
@@ -396,9 +396,9 @@ class KktState
          lagrV = 0;
 
          auto index_range = matrixCW.getRowRanges()[reduced_index];
-         for( int k = index_range.start; k < index_range.end; k++ )
+         for( int64_t k = index_range.start; k < index_range.end; k++ )
          {
-            int row = matrixCW.getColumns()[k];
+            int64_t row = matrixCW.getColumns()[k];
             lagrV += rowDuals[orig_row_index[row]] * matrixCW.getValues()[k];
          }
 
@@ -416,31 +416,31 @@ class KktState
    void
    getRowValues()
    {
-      const int nRows = problem.getNRows();
-      const int nCols = problem.getNCols();
+      const int64_t nRows = problem.getNRows();
+      const int64_t nCols = problem.getNCols();
       rowValues.resize( solSetRow.size() );
       REAL rowValue;
 
-      int reduced_row_index = 0;
+      int64_t reduced_row_index = 0;
       auto values = matrixRW.getValues();
 
       std::vector<int> orig_col_index;
       orig_col_index.reserve( nCols );
-      for( int i = 0; i < solSetCol.size(); i++ )
+      for( int64_t i = 0; i < solSetCol.size(); i++ )
          if( solSetCol[i] )
             orig_col_index.push_back( i );
       assert( orig_col_index.size() == nCols );
 
-      for( int i = 0; i < solSetRow.size(); i++ )
+      for( int64_t i = 0; i < solSetRow.size(); i++ )
       {
          if( !solSetRow[i] )
             continue;
 
          rowValue = 0;
          auto index_range = matrixRW.getRowRanges()[reduced_row_index];
-         for( int j = index_range.start; j < index_range.end; j++ )
+         for( int64_t j = index_range.start; j < index_range.end; j++ )
          {
-            int col = matrixRW.getColumns()[j];
+            int64_t col = matrixRW.getColumns()[j];
             assert( col >= 0 );
             assert( col < (int)nCols );
 
@@ -491,7 +491,7 @@ class KktChecker<REAL, CheckLevel::No_check>
 
    State
    initState( ProblemType type, Solution<REAL>& solution,
-              const Vec<int>& origcol_map, const Vec<int>& origrow_map,
+              const Vec<int64_t>& origcol_map, const Vec<int64_t>& origrow_map,
               CheckLevel checker_level )
    {
       return 0;
@@ -533,8 +533,8 @@ class KktChecker<REAL, CheckLevel::No_check>
    }
 
    void
-   addRowToProblem( const int row, const int length, const REAL* values,
-                    const int* coeffs, const REAL lhs, const REAL rhs,
+   addRowToProblem( const int64_t row, const int64_t length, const REAL* values,
+                    const int64_t* coeffs, const REAL lhs, const REAL rhs,
                     const bool lb_inf, const bool ub_inf )
    {
    }
@@ -562,8 +562,8 @@ class KktChecker<REAL, CheckLevel::Check>
    initState( ProblemType type, Solution<REAL>& solution,
               CheckLevel checker_level )
    {
-      int ncols = original_problem.getNCols();
-      int nrows = original_problem.getNRows();
+      int64_t ncols = original_problem.getNCols();
+      int64_t nrows = original_problem.getNRows();
       Vec<uint8_t> solSetColumns( ncols, 1 );
       Vec<uint8_t> solSetRows( nrows, 1 );
 
@@ -573,23 +573,23 @@ class KktChecker<REAL, CheckLevel::Check>
 
    State
    initState( ProblemType type, Solution<REAL>& solution,
-              const Vec<int>& origcol_map, const Vec<int>& origrow_map,
+              const Vec<int64_t>& origcol_map, const Vec<int64_t>& origrow_map,
               CheckLevel checker_level )
    {
-      int ncols = original_problem.getNCols();
-      int nrows = original_problem.getNRows();
+      int64_t ncols = original_problem.getNCols();
+      int64_t nrows = original_problem.getNRows();
       Vec<uint8_t> solSetColumns( ncols, 0 );
       Vec<uint8_t> solSetRows( nrows, 0 );
 
-      for( int k = 0; k < origcol_map.size(); ++k )
+      for( int64_t k = 0; k < origcol_map.size(); ++k )
       {
-         int origcol = origcol_map[k];
+         int64_t origcol = origcol_map[k];
          solSetCol[origcol] = true;
       }
 
-      for( int k = 0; k < origrow_map.size(); ++k )
+      for( int64_t k = 0; k < origrow_map.size(); ++k )
       {
-         int origrow = origrow_map[k];
+         int64_t origrow = origrow_map[k];
          solSetRow[origrow] = true;
       }
 
@@ -633,8 +633,8 @@ class KktChecker<REAL, CheckLevel::Check>
 
       // if problem type is REDUCED expand row / column bound vectors since
       // original_solution is already padded.
-      const int nRows = reduced_problem.getNRows();
-      const int nCols = reduced_problem.getNCols();
+      const int64_t nRows = reduced_problem.getNRows();
+      const int64_t nCols = reduced_problem.getNCols();
 
       if( solSetRows.size() > nRows )
       {
@@ -651,8 +651,8 @@ class KktChecker<REAL, CheckLevel::Check>
          rowUpper_reduced.resize( solSetRows.size(), 0 );
          rowLower_reduced.resize( solSetRows.size(), 0 );
 
-         int index = 0;
-         for( int k = 0; k < solSetRows.size(); ++k )
+         int64_t index = 0;
+         for( int64_t k = 0; k < solSetRows.size(); ++k )
          {
             if( solSetRows[k] )
             {
@@ -686,8 +686,8 @@ class KktChecker<REAL, CheckLevel::Check>
          colUpper_reduced.resize( solSetColumns.size(), 0 );
          colLower_reduced.resize( solSetColumns.size(), 0 );
 
-         int index = 0;
-         for( int k = 0; k < solSetColumns.size(); ++k )
+         int64_t index = 0;
+         for( int64_t k = 0; k < solSetColumns.size(); ++k )
          {
             if( solSetColumns[k] )
             {
@@ -818,8 +818,8 @@ class KktChecker<REAL, CheckLevel::Check>
    }
 
    void
-   addRowToProblem( const int row, const int length, const REAL* values,
-                    const int* coeffs, const REAL lhs, const REAL rhs,
+   addRowToProblem( const int64_t row, const int64_t length, const REAL* values,
+                    const int64_t* coeffs, const REAL lhs, const REAL rhs,
                     const bool lb_inf, const bool ub_inf )
    {
       addRow( problem, row, length, values, coeffs, lhs, rhs, lb_inf, ub_inf );
@@ -841,28 +841,28 @@ class KktChecker<REAL, CheckLevel::Check>
 
 template <typename REAL>
 bool
-rowLHSInf( const Problem<REAL>& problem, const int row )
+rowLHSInf( const Problem<REAL>& problem, const int64_t row )
 {
    return problem.getRowFlags()[row].test( RowFlag::kLhsInf );
 }
 
 template <typename REAL>
 bool
-rowRHSInf( const Problem<REAL>& problem, const int row )
+rowRHSInf( const Problem<REAL>& problem, const int64_t row )
 {
    return problem.getRowFlags()[row].test( RowFlag::kRhsInf );
 }
 
 template <typename REAL>
 bool
-colLBInf( const Problem<REAL>& problem, const int col )
+colLBInf( const Problem<REAL>& problem, const int64_t col )
 {
    return problem.getColFlags()[col].test( ColFlag::kLbInf );
 }
 
 template <typename REAL>
 bool
-colUBInf( const Problem<REAL>& problem, const int col )
+colUBInf( const Problem<REAL>& problem, const int64_t col )
 {
    return problem.getColFlags()[col].test( ColFlag::kUbInf );
 }

--- a/src/papilo/misc/Num.hpp
+++ b/src/papilo/misc/Num.hpp
@@ -73,11 +73,11 @@ class provides_numerator_and_denominator_overloads
 
    template <typename T2>
    static decltype( numerator( std::declval<T2>() ) )
-   test_numerator( int );
+   test_numerator( int64_t );
 
    template <typename T2>
    static decltype( numerator( std::declval<T2>() ) )
-   test_denominator( int );
+   test_denominator( int64_t );
 
    template <typename T2>
    static no

--- a/src/papilo/misc/NumericalStatistics.hpp
+++ b/src/papilo/misc/NumericalStatistics.hpp
@@ -63,8 +63,8 @@ class NumericalStatistics
       const Vec<REAL>& lhs = cm.getLeftHandSides();
       const Vec<REAL>& rhs = cm.getRightHandSides();
 
-      int nrows = cm.getNRows();
-      int ncols = cm.getNCols();
+      int64_t nrows = cm.getNRows();
+      int64_t ncols = cm.getNCols();
 
       stats.matrixMin = 0.0;
       stats.matrixMax = 0.0;
@@ -74,7 +74,7 @@ class NumericalStatistics
       bool rhsMinSet = false;
 
       // Row dynamism, matrixMin/Max, RHS
-      for( int r = 0; r < nrows; ++r )
+      for( int64_t r = 0; r < nrows; ++r )
       {
          // matrixMin/Max
          const SparseVectorView<REAL>& row = cm.getRowCoefficients( r );
@@ -136,7 +136,7 @@ class NumericalStatistics
       bool boundsMinSet = false;
 
       // Column dynamism, Variable Bounds
-      for( int c = 0; c < ncols; ++c )
+      for( int64_t c = 0; c < ncols; ++c )
       {
          // Column dynamism
          const SparseVectorView<REAL>& col = cm.getColumnCoefficients( c );
@@ -207,7 +207,7 @@ class NumericalStatistics
       stats.objMin = 0.0;
       bool objMinSet = false;
 
-      for( int i = 0; i < obj.coefficients.size(); ++i )
+      for( int64_t i = 0; i < obj.coefficients.size(); ++i )
       {
          if( obj.coefficients[i] != 0 )
          {

--- a/src/papilo/misc/ParameterSet.hpp
+++ b/src/papilo/misc/ParameterSet.hpp
@@ -345,8 +345,8 @@ class ParameterSet
 
    void
    addParameter( const char* key, const char* description, std::int64_t& val,
-                 std::int64_t min = std::numeric_limits<std::int64_t>::min(),
-                 std::int64_t max = std::numeric_limits<std::int64_t>::max() )
+                 int64_t min = std::numeric_limits<int64_t>::min(),
+                 int64_t max = std::numeric_limits<int64_t>::max() )
    {
       if( parameters.count( key ) != 0 )
          throw std::invalid_argument(
@@ -354,7 +354,7 @@ class ParameterSet
 
       parameters.emplace(
           key, Parameter{ description,
-                          NumericalOption<std::int64_t>{ &val, min, max } } );
+                          NumericalOption<int64_t>{ &val, min, max } } );
    }
 
    void

--- a/src/papilo/misc/Vec.hpp
+++ b/src/papilo/misc/Vec.hpp
@@ -32,7 +32,7 @@ namespace papilo
 template <typename T>
 using Vec = std::vector<T, Allocator<T>>;
 
-template <typename T, int N>
+template <typename T, int64_t N>
 using SmallVec = boost::container::small_vector<T, N, Allocator<T>>;
 
 } // namespace papilo

--- a/src/papilo/misc/VectorUtils.hpp
+++ b/src/papilo/misc/VectorUtils.hpp
@@ -69,7 +69,7 @@ compareColBounds( const Vec<REAL>& first_values, const Vec<REAL>& second_values,
                   const Vec<ColFlags>& first_flags,
                   const Vec<ColFlags>& second_flags, const Num<REAL>& num )
 {
-   int size = first_values.size();
+   int64_t size = first_values.size();
    if( size != first_flags.size() )
       return false;
    if( size != second_values.size() )
@@ -77,7 +77,7 @@ compareColBounds( const Vec<REAL>& first_values, const Vec<REAL>& second_values,
    if( size != second_flags.size() )
       return false;
 
-   for( int i = 0; i < size; i++ )
+   for( int64_t i = 0; i < size; i++ )
    {
       if( ( first_flags[i].test( ColFlag::kLbInf ) &&
             second_flags[i].test( ColFlag::kLbInf ) ) ||
@@ -98,7 +98,7 @@ compareRowBounds( const Vec<REAL>& first_values, const Vec<REAL>& second_values,
                   const Vec<RowFlags>& first_flags,
                   const Vec<RowFlags>& second_flags, const Num<REAL>& num )
 {
-   int size = first_values.size();
+   int64_t size = first_values.size();
    if( size != first_flags.size() )
       return false;
    if( size != second_values.size() )
@@ -106,7 +106,7 @@ compareRowBounds( const Vec<REAL>& first_values, const Vec<REAL>& second_values,
    if( size != second_flags.size() )
       return false;
 
-   for( int i = 0; i < size; i++ )
+   for( int64_t i = 0; i < size; i++ )
    {
       if( ( first_flags[i].test( RowFlag::kLhsInf ) &&
             second_flags[i].test( RowFlag::kLhsInf ) ) ||
@@ -193,10 +193,10 @@ compareProblems( const Problem<REAL>& first, const Problem<REAL>& second,
                  const Num<REAL>& num )
 {
    // ncols, nrows
-   int nRows1 = first.getNRows();
-   int nRows2 = second.getNRows();
-   const int nCols1 = first.getNCols();
-   const int nCols2 = second.getNCols();
+   int64_t nRows1 = first.getNRows();
+   int64_t nRows2 = second.getNRows();
+   const int64_t nCols1 = first.getNCols();
+   const int64_t nCols2 = second.getNCols();
 
    if( nRows1 != nRows2 )
       return false;

--- a/src/papilo/misc/compress_vector.hpp
+++ b/src/papilo/misc/compress_vector.hpp
@@ -33,12 +33,12 @@ namespace papilo
 /// helper function to compress a vector-like container using the given mapping
 template <typename VEC>
 void
-compress_vector( const Vec<int>& mapping, VEC& vec )
+compress_vector( const Vec<int64_t>& mapping, VEC& vec )
 {
    assert( vec.size() == mapping.size() );
 
-   int newSize = 0;
-   for( int i = 0; i != static_cast<int>( vec.size() ); ++i )
+   int64_t newSize = 0;
+   for( int64_t i = 0; i != static_cast<int>( vec.size() ); ++i )
    {
       assert( mapping[i] <= i );
 
@@ -55,12 +55,12 @@ compress_vector( const Vec<int>& mapping, VEC& vec )
 /// given mapping
 template <typename VEC>
 void
-compress_index_vector( const Vec<int>& mapping, VEC& vec )
+compress_index_vector( const Vec<int64_t>& mapping, VEC& vec )
 {
-   int offset = 0;
+   int64_t offset = 0;
    for( std::size_t i = 0; i < vec.size(); ++i )
    {
-      int newindex = mapping[vec[i]];
+      int64_t newindex = mapping[vec[i]];
       if( newindex != -1 )
          vec[i - offset] = newindex;
       else

--- a/src/papilo/presolvers/CoefficientStrengthening.hpp
+++ b/src/papilo/presolvers/CoefficientStrengthening.hpp
@@ -77,12 +77,12 @@ CoefficientStrengthening<REAL>::execute(
 
    Vec<std::pair<REAL, int>> integerCoefficients;
 
-   for( int i : changedactivities )
+   for( int64_t i : changedactivities )
    {
       auto rowcoefficients = constMatrix.getRowCoefficients( i );
       const REAL* coefficients = rowcoefficients.getValues();
-      const int len = rowcoefficients.getLength();
-      const int* coefindices = rowcoefficients.getIndices();
+      const int64_t len = rowcoefficients.getLength();
+      const int64_t* coefindices = rowcoefficients.getIndices();
 
       if( ( !rflags[i].test( RowFlag::kLhsInf ) &&
             !rflags[i].test( RowFlag::kRhsInf ) ) ||
@@ -91,7 +91,7 @@ CoefficientStrengthening<REAL>::execute(
 
       REAL rhs;
       REAL maxact;
-      int scale;
+      int64_t scale;
 
       // normalize constraint to a * x <= b constraint, remember if it was
       // scaled by -1
@@ -131,7 +131,7 @@ CoefficientStrengthening<REAL>::execute(
       else if( num.isFeasEq( newabscoef, ceil( newabscoef ) ) )
          newabscoef = ceil( newabscoef );
 
-      for( int k = 0; k != len; ++k )
+      for( int64_t k = 0; k != len; ++k )
       {
          if( !cflags[coefindices[k]].test( ColFlag::kIntegral,
                                            ColFlag::kImplInt ) ||

--- a/src/papilo/presolvers/ConstraintPropagation.hpp
+++ b/src/papilo/presolvers/ConstraintPropagation.hpp
@@ -80,7 +80,7 @@ ConstraintPropagation<REAL>::execute( const Problem<REAL>& problem,
                    num.getFeasTol() }
            : REAL{ 0 };
 
-   auto add_boundchange = [&]( BoundChange boundChange, int col, REAL val ) {
+   auto add_boundchange = [&]( BoundChange boundChange, int64_t col, REAL val ) {
       // do not accept huge values as bounds
       if( num.isHugeVal( val ) )
          return;
@@ -172,7 +172,7 @@ ConstraintPropagation<REAL>::execute( const Problem<REAL>& problem,
       }
    };
 
-   for( int row : changedactivities )
+   for( int64_t row : changedactivities )
    {
       auto rowvec = consMatrix.getRowCoefficients( row );
 

--- a/src/papilo/presolvers/DualFix.hpp
+++ b/src/papilo/presolvers/DualFix.hpp
@@ -78,15 +78,15 @@ DualFix<REAL>::execute( const Problem<REAL>& problem,
    const Vec<REAL>& objective = problem.getObjective().coefficients;
    const Vec<REAL>& lbs = problem.getLowerBounds();
    const Vec<REAL>& ubs = problem.getUpperBounds();
-   const int ncols = consMatrix.getNCols();
+   const int64_t ncols = consMatrix.getNCols();
    const Vec<RowFlags>& rflags = consMatrix.getRowFlags();
-   const Vec<int>& colsize = consMatrix.getColSizes();
+   const Vec<int64_t>& colsize = consMatrix.getColSizes();
    const Vec<REAL>& lhs = consMatrix.getLeftHandSides();
    const Vec<REAL>& rhs = consMatrix.getRightHandSides();
 
    PresolveStatus result = PresolveStatus::kUnchanged;
 
-   for( int i = 0; i != ncols; ++i )
+   for( int64_t i = 0; i != ncols; ++i )
    {
       // skip inactive columns
       if( cflags[i].test( ColFlag::kInactive ) )
@@ -98,11 +98,11 @@ DualFix<REAL>::execute( const Problem<REAL>& problem,
          continue;
 
       auto colvec = consMatrix.getColumnCoefficients( i );
-      int collen = colvec.getLength();
+      int64_t collen = colvec.getLength();
       const REAL* values = colvec.getValues();
-      const int* rowinds = colvec.getIndices();
-      int nuplocks = 0;
-      int ndownlocks = 0;
+      const int64_t* rowinds = colvec.getIndices();
+      int64_t nuplocks = 0;
+      int64_t ndownlocks = 0;
 
       // count "lock" for objective function
       if( objective[i] < 0 )
@@ -110,7 +110,7 @@ DualFix<REAL>::execute( const Problem<REAL>& problem,
       else if( objective[i] > 0 )
          ++nuplocks;
 
-      for( int j = 0; j != collen; ++j )
+      for( int64_t j = 0; j != collen; ++j )
       {
          count_locks( values[j], rflags[rowinds[j]], ndownlocks, nuplocks );
 
@@ -177,7 +177,7 @@ DualFix<REAL>::execute( const Problem<REAL>& problem,
       {
          // Function checks if considered row allows dual bound strengthening
          // and calculates tightest bound for this row.
-         auto check_row = []( int ninf, REAL activity, const REAL& side,
+         auto check_row = []( int64_t ninf, REAL activity, const REAL& side,
                               const REAL& coeff, const REAL& boundval,
                               bool boundinf, bool& skip, REAL& cand_bound ) {
             switch( ninf )
@@ -214,9 +214,9 @@ DualFix<REAL>::execute( const Problem<REAL>& problem,
             REAL new_UB;
 
             // go through all rows with non-zero entry
-            for( int j = 0; j != collen; ++j )
+            for( int64_t j = 0; j != collen; ++j )
             {
-               int row = rowinds[j];
+               int64_t row = rowinds[j];
                // candidate for new upper bound
                REAL cand_bound;
 
@@ -320,9 +320,9 @@ DualFix<REAL>::execute( const Problem<REAL>& problem,
             REAL new_LB;
 
             // go through all rows with non-zero entry
-            for( int j = 0; j != collen; ++j )
+            for( int64_t j = 0; j != collen; ++j )
             {
-               int row = rowinds[j];
+               int64_t row = rowinds[j];
                // candidate for new lower bound
                REAL cand_bound;
 

--- a/src/papilo/presolvers/FixContinuous.hpp
+++ b/src/papilo/presolvers/FixContinuous.hpp
@@ -72,14 +72,14 @@ FixContinuous<REAL>::execute( const Problem<REAL>& problem,
    const auto& lbs = problem.getLowerBounds();
    const auto& ubs = problem.getUpperBounds();
 
-   const int ncols = consMatrix.getNCols();
+   const int64_t ncols = consMatrix.getNCols();
    const auto& colsize = consMatrix.getColSizes();
 
    PresolveStatus result = PresolveStatus::kUnchanged;
    if( num.getFeasTol() == REAL{ 0 } )
       return result;
 
-   for( int i = 0; i < ncols; ++i )
+   for( int64_t i = 0; i < ncols; ++i )
    {
       // dont fix removed or empty columns, integral columns, columns with
       // infinity bounds, columns that are already fixed, and columns whose

--- a/src/papilo/presolvers/ImplIntDetection.hpp
+++ b/src/papilo/presolvers/ImplIntDetection.hpp
@@ -80,7 +80,7 @@ ImplIntDetection<REAL>::execute( const Problem<REAL>& problem,
 
    PresolveStatus result = PresolveStatus::kUnchanged;
 
-   for( int col = 0; col != ncols; ++col )
+   for( int64_t col = 0; col != ncols; ++col )
    {
       if( cflags[col].test( ColFlag::kIntegral, ColFlag::kImplInt,
                             ColFlag::kInactive ) )
@@ -91,13 +91,13 @@ ImplIntDetection<REAL>::execute( const Problem<REAL>& problem,
       bool impliedint = false;
 
       auto colvec = consmatrix.getColumnCoefficients( col );
-      int collen = colvec.getLength();
-      const int* colrows = colvec.getIndices();
+      int64_t collen = colvec.getLength();
+      const int64_t* colrows = colvec.getIndices();
       const REAL* colvals = colvec.getValues();
 
-      for( int i = 0; i != collen; ++i )
+      for( int64_t i = 0; i != collen; ++i )
       {
-         int row = colrows[i];
+         int64_t row = colrows[i];
 
          if( rflags[row].test( RowFlag::kRedundant ) ||
              !rflags[row].test( RowFlag::kEquation ) )
@@ -109,15 +109,15 @@ ImplIntDetection<REAL>::execute( const Problem<REAL>& problem,
             continue;
 
          auto rowvec = consmatrix.getRowCoefficients( row );
-         int rowlen = rowvec.getLength();
-         const int* rowcols = rowvec.getIndices();
+         int64_t rowlen = rowvec.getLength();
+         const int64_t* rowcols = rowvec.getIndices();
          const REAL* rowvals = rowvec.getValues();
 
          impliedint = true;
 
-         for( int j = 0; j != rowlen; ++j )
+         for( int64_t j = 0; j != rowlen; ++j )
          {
-            int rowcol = rowcols[j];
+            int64_t rowcol = rowcols[j];
 
             if( rowcol == col )
                continue;
@@ -155,9 +155,9 @@ ImplIntDetection<REAL>::execute( const Problem<REAL>& problem,
 
       impliedint = true;
 
-      for( int i = 0; i != collen; ++i )
+      for( int64_t i = 0; i != collen; ++i )
       {
-         int row = colrows[i];
+         int64_t row = colrows[i];
 
          if( rflags[row].test( RowFlag::kRedundant ) )
             continue;
@@ -179,13 +179,13 @@ ImplIntDetection<REAL>::execute( const Problem<REAL>& problem,
          }
 
          auto rowvec = consmatrix.getRowCoefficients( row );
-         int rowlen = rowvec.getLength();
-         const int* rowcols = rowvec.getIndices();
+         int64_t rowlen = rowvec.getLength();
+         const int64_t* rowcols = rowvec.getIndices();
          const REAL* rowvals = rowvec.getValues();
 
-         for( int j = 0; j != rowlen; ++j )
+         for( int64_t j = 0; j != rowlen; ++j )
          {
-            int rowcol = rowcols[j];
+            int64_t rowcol = rowcols[j];
 
             if( rowcol == col )
                continue;

--- a/src/papilo/presolvers/SimpleProbing.hpp
+++ b/src/papilo/presolvers/SimpleProbing.hpp
@@ -77,9 +77,9 @@ SimpleProbing<REAL>::execute( const Problem<REAL>& problem,
    const auto& rflags = constMatrix.getRowFlags();
 
    PresolveStatus result = PresolveStatus::kUnchanged;
-   int nrows = problem.getNRows();
+   int64_t nrows = problem.getNRows();
 
-   for( int i = 0; i != nrows; ++i )
+   for( int64_t i = 0; i != nrows; ++i )
    {
       if( !rflags[i].test( RowFlag::kEquation ) || rowsize[i] <= 2 ||
           activities[i].ninfmin != 0 || activities[i].ninfmax != 0 ||
@@ -94,15 +94,15 @@ SimpleProbing<REAL>::execute( const Problem<REAL>& problem,
 
       auto rowvec = constMatrix.getRowCoefficients( i );
       const REAL* rowvals = rowvec.getValues();
-      const int* rowcols = rowvec.getIndices();
-      const int rowlen = rowvec.getLength();
+      const int64_t* rowcols = rowvec.getIndices();
+      const int64_t rowlen = rowvec.getLength();
 
       REAL bincoef = activities[i].max - rhs_values[i];
-      int bincol = -1;
+      int64_t bincol = -1;
 
-      for( int k = 0; k != rowlen; ++k )
+      for( int64_t k = 0; k != rowlen; ++k )
       {
-         int col = rowcols[k];
+         int64_t col = rowcols[k];
          assert( !cflags[col].test( ColFlag::kUnbounded ) );
          if( !cflags[col].test( ColFlag::kIntegral ) ||
              domains.lower_bounds[col] != 0 || domains.upper_bounds[col] != 1 ||
@@ -128,9 +128,9 @@ SimpleProbing<REAL>::execute( const Problem<REAL>& problem,
              rowlen - 1 );
 
          result = PresolveStatus::kReduced;
-         for( int k = 0; k != rowlen; ++k )
+         for( int64_t k = 0; k != rowlen; ++k )
          {
-            int col = rowcols[k];
+            int64_t col = rowcols[k];
             if( col == bincol )
                continue;
 

--- a/src/papilo/presolvers/SimpleSubstitution.hpp
+++ b/src/papilo/presolvers/SimpleSubstitution.hpp
@@ -85,9 +85,9 @@ SimpleSubstitution<REAL>::execute( const Problem<REAL>& problem,
 
    PresolveStatus result = PresolveStatus::kUnchanged;
 
-   for( int k = 0; k < nrows; ++k )
+   for( int64_t k = 0; k < nrows; ++k )
    {
-      int i = rowperm[k];
+      int64_t i = rowperm[k];
       // check that equality flag is correct or row is redundant
       assert( rflags[i].test( RowFlag::kRedundant ) ||
               ( !rflags[i].test( RowFlag::kEquation ) &&
@@ -105,11 +105,11 @@ SimpleSubstitution<REAL>::execute( const Problem<REAL>& problem,
       auto rowvec = constMatrix.getRowCoefficients( i );
       assert( rowvec.getLength() == 2 );
       const REAL* vals = rowvec.getValues();
-      const int* inds = rowvec.getIndices();
+      const int64_t* inds = rowvec.getIndices();
       REAL rhs = rhs_values[i];
 
-      int subst;
-      int stay;
+      int64_t subst;
+      int64_t stay;
 
       if( cflags[inds[0]].test( ColFlag::kIntegral ) !=
           cflags[inds[1]].test( ColFlag::kIntegral ) )

--- a/src/papilo/presolvers/SingletonCols.hpp
+++ b/src/papilo/presolvers/SingletonCols.hpp
@@ -83,8 +83,8 @@ SingletonCols<REAL>::execute( const Problem<REAL>& problem,
 
    PresolveStatus result = PresolveStatus::kUnchanged;
 
-   auto handleEquation = [&]( int col, bool lbimplied, bool ubimplied,
-                              const REAL& val, int row, bool impliedeq,
+   auto handleEquation = [&]( int64_t col, bool lbimplied, bool ubimplied,
+                              const REAL& val, int64_t row, bool impliedeq,
                               const REAL& side ) {
       if( !impliedeq && rowsize[row] <= 1 )
          return;
@@ -159,15 +159,15 @@ SingletonCols<REAL>::execute( const Problem<REAL>& problem,
       }
    };
 
-   int firstNewSingleton = problemUpdate.getFirstNewSingletonCol();
+   int64_t firstNewSingleton = problemUpdate.getFirstNewSingletonCol();
    for( std::size_t i = firstNewSingleton; i != singletonCols.size(); ++i )
    {
-      int col = singletonCols[i];
+      int64_t col = singletonCols[i];
 
       assert( colsize[col] == 1 );
       assert( constMatrix.getColumnCoefficients( col ).getLength() == 1 );
 
-      int row = constMatrix.getColumnCoefficients( col ).getIndices()[0];
+      int64_t row = constMatrix.getColumnCoefficients( col ).getIndices()[0];
 
       const REAL& val = constMatrix.getColumnCoefficients( col ).getValues()[0];
 
@@ -210,9 +210,9 @@ SingletonCols<REAL>::execute( const Problem<REAL>& problem,
             bool unsuitableForSubstitution = false;
 
             auto rowvec = constMatrix.getRowCoefficients( row );
-            const int* rowinds = rowvec.getIndices();
+            const int64_t* rowinds = rowvec.getIndices();
             const REAL* rowvals = rowvec.getValues();
-            for( int i = 0; i != rowvec.getLength(); ++i )
+            for( int64_t i = 0; i != rowvec.getLength(); ++i )
             {
                if( rowinds[i] == col )
                   continue;
@@ -251,8 +251,8 @@ SingletonCols<REAL>::execute( const Problem<REAL>& problem,
             continue;
       }
 
-      int nuplocks = 0;
-      int ndownlocks = 0;
+      int64_t nuplocks = 0;
+      int64_t ndownlocks = 0;
 
       count_locks( val, rflags[row], ndownlocks, nuplocks );
 

--- a/src/papilo/presolvers/SingletonStuffing.hpp
+++ b/src/papilo/presolvers/SingletonStuffing.hpp
@@ -81,11 +81,11 @@ SingletonStuffing<REAL>::execute( const Problem<REAL>& problem,
    const auto& obj = problem.getObjective().coefficients;
 
    PresolveStatus result = PresolveStatus::kUnchanged;
-   Vec<int> rowsWithPenaltySingletons;
+   Vec<int64_t> rowsWithPenaltySingletons;
    Vec<uint8_t> penaltyVarCount( nrows );
 
-   auto handleEquation = [&]( int col, bool lbimplied, bool ubimplied,
-                              const REAL& val, int row, bool impliedeq,
+   auto handleEquation = [&]( int64_t col, bool lbimplied, bool ubimplied,
+                              const REAL& val, int64_t row, bool impliedeq,
                               const REAL& side ) {
       if( !impliedeq && rowsize[row] <= 1 )
          return;
@@ -160,12 +160,12 @@ SingletonStuffing<REAL>::execute( const Problem<REAL>& problem,
       }
    };
 
-   for( int col : singletonCols )
+   for( int64_t col : singletonCols )
    {
       assert( colsize[col] == 1 );
       assert( constMatrix.getColumnCoefficients( col ).getLength() == 1 );
 
-      int row = constMatrix.getColumnCoefficients( col ).getIndices()[0];
+      int64_t row = constMatrix.getColumnCoefficients( col ).getIndices()[0];
       const REAL& val = constMatrix.getColumnCoefficients( col ).getValues()[0];
 
       assert( !constMatrix.isRowRedundant( row ) );
@@ -206,9 +206,9 @@ SingletonStuffing<REAL>::execute( const Problem<REAL>& problem,
             bool unsuitableForSubstitution = false;
 
             auto rowvec = constMatrix.getRowCoefficients( row );
-            const int* rowinds = rowvec.getIndices();
+            const int64_t* rowinds = rowvec.getIndices();
             const REAL* rowvals = rowvec.getValues();
-            for( int i = 0; i != rowvec.getLength(); ++i )
+            for( int64_t i = 0; i != rowvec.getLength(); ++i )
             {
                if( rowinds[i] == col )
                   continue;
@@ -247,8 +247,8 @@ SingletonStuffing<REAL>::execute( const Problem<REAL>& problem,
             continue;
       }
 
-      int nuplocks = 0;
-      int ndownlocks = 0;
+      int64_t nuplocks = 0;
+      int64_t ndownlocks = 0;
 
       count_locks( val, rflags[row], ndownlocks, nuplocks );
 
@@ -476,14 +476,14 @@ SingletonStuffing<REAL>::execute( const Problem<REAL>& problem,
 
    Vec<std::pair<int, REAL>> penaltyvars;
 
-   for( int row : rowsWithPenaltySingletons )
+   for( int64_t row : rowsWithPenaltySingletons )
    {
       assert( rflags[row].test( RowFlag::kLhsInf ) ||
               rflags[row].test( RowFlag::kRhsInf ) );
       assert( !rflags[row].test( RowFlag::kLhsInf ) ||
               !rflags[row].test( RowFlag::kRhsInf ) );
 
-      int scale;
+      int64_t scale;
       REAL rhs;
       REAL maxresact = 0;
 
@@ -499,15 +499,15 @@ SingletonStuffing<REAL>::execute( const Problem<REAL>& problem,
       }
 
       auto rowvec = constMatrix.getRowCoefficients( row );
-      const int* rowinds = rowvec.getIndices();
+      const int64_t* rowinds = rowvec.getIndices();
       const REAL* rowvals = rowvec.getValues();
-      const int len = rowvec.getLength();
+      const int64_t len = rowvec.getLength();
 
       // TODO do singleton stuffing
       bool suitable = true;
-      for( int i = 0; i != len; ++i )
+      for( int64_t i = 0; i != len; ++i )
       {
-         int col = rowinds[i];
+         int64_t col = rowinds[i];
          REAL coeff = scale * rowvals[i];
 
          // if the column is a singleton and not integral it could be a
@@ -580,7 +580,7 @@ SingletonStuffing<REAL>::execute( const Problem<REAL>& problem,
          continue;
       }
 
-      int npenaltyvars = penaltyvars.size();
+      int64_t npenaltyvars = penaltyvars.size();
 
       pdqsort( penaltyvars.begin(), penaltyvars.end(),
                [&]( const std::pair<int, REAL>& c1,
@@ -592,7 +592,7 @@ SingletonStuffing<REAL>::execute( const Problem<REAL>& problem,
       std::size_t k = 0;
       while( k < penaltyvars.size() && num.isFeasLT( rhs, 0 ) )
       {
-         int col = penaltyvars[k].first;
+         int64_t col = penaltyvars[k].first;
          const REAL& coeff = penaltyvars[k].second;
 
          // for non-singletons or singletons that where not handled in the
@@ -628,7 +628,7 @@ SingletonStuffing<REAL>::execute( const Problem<REAL>& problem,
 
          while( k < penaltyvars.size() )
          {
-            int col = penaltyvars[k].first;
+            int64_t col = penaltyvars[k].first;
             const REAL& coeff = penaltyvars[k].second;
 
             if( coeff < 0 )

--- a/src/papilolib.cpp
+++ b/src/papilolib.cpp
@@ -130,8 +130,8 @@ struct Papilo_Problem
 };
 
 PAPILO_PROBLEM*
-papilo_problem_create( double infinity, const char* name, int nnz_hint,
-                       int row_hint, int col_hint )
+papilo_problem_create( double infinity, const char* name, int64_t nnz_hint,
+                       int64_t row_hint, int64_t col_hint )
 {
    assert( nnz_hint >= 0 );
 
@@ -151,7 +151,7 @@ papilo_problem_create( double infinity, const char* name, int nnz_hint,
 }
 
 int
-papilo_problem_add_cols( PAPILO_PROBLEM* problem, int num, const double* lb,
+papilo_problem_add_cols( PAPILO_PROBLEM* problem, int64_t num, const double* lb,
                          const double* ub, const unsigned char* integral,
                          const double* obj, const char** colnames )
 {
@@ -160,13 +160,13 @@ papilo_problem_add_cols( PAPILO_PROBLEM* problem, int num, const double* lb,
    if( num == 0 )
       return -1;
 
-   int ncols = problem->problemBuilder.getNumCols();
+   int64_t ncols = problem->problemBuilder.getNumCols();
 
    problem->problemBuilder.setNumCols( ncols + num );
 
-   for( int i = 0; i != num; ++i )
+   for( int64_t i = 0; i != num; ++i )
    {
-      int col = ncols + i;
+      int64_t col = ncols + i;
       problem->problemBuilder.setObj( col, obj[i] );
 
       bool isLbInf = lb[i] <= -problem->infinity;
@@ -198,11 +198,11 @@ papilo_problem_add_col( PAPILO_PROBLEM* problem, double lb, double ub,
                         unsigned char integral, double obj,
                         const char* colname )
 {
-   int ncols = problem->problemBuilder.getNumCols();
+   int64_t ncols = problem->problemBuilder.getNumCols();
 
    problem->problemBuilder.setNumCols( ncols + 1 );
 
-   int col = ncols;
+   int64_t col = ncols;
    problem->problemBuilder.setObj( col, obj );
 
    bool isLbInf = lb <= -problem->infinity;
@@ -248,32 +248,32 @@ papilo_problem_get_num_nonzeros( PAPILO_PROBLEM* problem )
 }
 
 void
-papilo_problem_change_col_lb( PAPILO_PROBLEM* problem, int col, double lb )
+papilo_problem_change_col_lb( PAPILO_PROBLEM* problem, int64_t col, double lb )
 {
    problem->problemBuilder.setColLb( col, lb );
 }
 
 void
-papilo_problem_change_col_ub( PAPILO_PROBLEM* problem, int col, double ub )
+papilo_problem_change_col_ub( PAPILO_PROBLEM* problem, int64_t col, double ub )
 {
    problem->problemBuilder.setColUb( col, ub );
 }
 
 void
-papilo_problem_change_col_integral( PAPILO_PROBLEM* problem, int col,
+papilo_problem_change_col_integral( PAPILO_PROBLEM* problem, int64_t col,
                                     unsigned char integral )
 {
    problem->problemBuilder.setColIntegral( col, integral );
 }
 
 void
-papilo_problem_change_col_obj( PAPILO_PROBLEM* problem, int col, double obj )
+papilo_problem_change_col_obj( PAPILO_PROBLEM* problem, int64_t col, double obj )
 {
    problem->problemBuilder.setObj( col, obj );
 }
 
 int
-papilo_problem_add_simple_rows( PAPILO_PROBLEM* problem, int num,
+papilo_problem_add_simple_rows( PAPILO_PROBLEM* problem, int64_t num,
                                 const unsigned char* rowtypes,
                                 const double* side, const char** rownames )
 {
@@ -282,13 +282,13 @@ papilo_problem_add_simple_rows( PAPILO_PROBLEM* problem, int num,
    if( num == 0 )
       return -1;
 
-   int nrows = problem->problemBuilder.getNumRows();
+   int64_t nrows = problem->problemBuilder.getNumRows();
 
    problem->problemBuilder.setNumRows( nrows + num );
 
-   for( int i = 0; i != num; ++i )
+   for( int64_t i = 0; i != num; ++i )
    {
-      int row = nrows + i;
+      int64_t row = nrows + i;
 
       switch( rowtypes[i] )
       {
@@ -320,7 +320,7 @@ papilo_problem_add_simple_rows( PAPILO_PROBLEM* problem, int num,
 }
 
 int
-papilo_problem_add_generic_rows( PAPILO_PROBLEM* problem, int num,
+papilo_problem_add_generic_rows( PAPILO_PROBLEM* problem, int64_t num,
                                  const double* lhs, const double* rhs,
                                  const char** rownames )
 {
@@ -329,13 +329,13 @@ papilo_problem_add_generic_rows( PAPILO_PROBLEM* problem, int num,
    if( num == 0 )
       return -1;
 
-   int nrows = problem->problemBuilder.getNumRows();
+   int64_t nrows = problem->problemBuilder.getNumRows();
 
    problem->problemBuilder.setNumRows( nrows + num );
 
-   for( int i = 0; i != num; ++i )
+   for( int64_t i = 0; i != num; ++i )
    {
-      int row = nrows + i;
+      int64_t row = nrows + i;
 
       bool isLhsInf = lhs[i] <= -problem->infinity;
       bool isRhsInf = rhs[i] >= problem->infinity;
@@ -366,11 +366,11 @@ int
 papilo_problem_add_simple_row( PAPILO_PROBLEM* problem, unsigned char rowtype,
                                double side, const char* rowname )
 {
-   int nrows = problem->problemBuilder.getNumRows();
+   int64_t nrows = problem->problemBuilder.getNumRows();
 
    problem->problemBuilder.setNumRows( nrows + 1 );
 
-   int row = nrows;
+   int64_t row = nrows;
 
    switch( rowtype )
    {
@@ -404,11 +404,11 @@ int
 papilo_problem_add_generic_row( PAPILO_PROBLEM* problem, double lhs, double rhs,
                                 const char* rowname )
 {
-   int nrows = problem->problemBuilder.getNumRows();
+   int64_t nrows = problem->problemBuilder.getNumRows();
 
    problem->problemBuilder.setNumRows( nrows + 1 );
 
-   int row = nrows;
+   int64_t row = nrows;
 
    bool isLhsInf = lhs <= -problem->infinity;
    bool isRhsInf = rhs >= problem->infinity;
@@ -443,41 +443,41 @@ papilo_problem_free( PAPILO_PROBLEM* prob )
 }
 
 void
-papilo_problem_add_nonzero( PAPILO_PROBLEM* problem, int row, int col,
+papilo_problem_add_nonzero( PAPILO_PROBLEM* problem, int64_t row, int64_t col,
                             double val )
 {
    problem->problemBuilder.addEntry( row, col, val );
 }
 
 void
-papilo_problem_add_nonzeros_row( PAPILO_PROBLEM* problem, int row, int num,
-                                 const int* cols, const double* vals )
+papilo_problem_add_nonzeros_row( PAPILO_PROBLEM* problem, int64_t row, int64_t num,
+                                 const int64_t* cols, const double* vals )
 {
    problem->problemBuilder.addRowEntries( row, num, cols, vals );
 }
 
 void
-papilo_problem_add_nonzeros_col( PAPILO_PROBLEM* problem, int col, int num,
-                                 const int* rows, const double* vals )
+papilo_problem_add_nonzeros_col( PAPILO_PROBLEM* problem, int64_t col, int64_t num,
+                                 const int64_t* rows, const double* vals )
 {
    problem->problemBuilder.addColEntries( col, num, rows, vals );
 }
 
 void
-papilo_problem_add_nonzeros_csr( PAPILO_PROBLEM* problem, const int* rowstart,
-                                 const int* cols, const double* vals )
+papilo_problem_add_nonzeros_csr( PAPILO_PROBLEM* problem, const int64_t* rowstart,
+                                 const int64_t* cols, const double* vals )
 {
-   for( int row = 0; row != problem->problemBuilder.getNumRows(); ++row )
+   for( int64_t row = 0; row != problem->problemBuilder.getNumRows(); ++row )
       problem->problemBuilder.addRowEntries(
           row, rowstart[row + 1] - rowstart[row], cols + rowstart[row],
           vals + rowstart[row] );
 }
 
 void
-papilo_problem_add_nonzeros_csc( PAPILO_PROBLEM* problem, const int* colstart,
-                                 const int* rows, const double* vals )
+papilo_problem_add_nonzeros_csc( PAPILO_PROBLEM* problem, const int64_t* colstart,
+                                 const int64_t* rows, const double* vals )
 {
-   for( int col = 0; col != problem->problemBuilder.getNumCols(); ++col )
+   for( int64_t col = 0; col != problem->problemBuilder.getNumCols(); ++col )
       problem->problemBuilder.addColEntries(
           col, colstart[col + 1] - colstart[col], rows + colstart[col],
           vals + colstart[col] );
@@ -737,7 +737,7 @@ papilo_solver_set_param_real( PAPILO_SOLVER* solver, const char* key,
 }
 
 PAPILO_PARAM_RESULT
-papilo_solver_set_param_int( PAPILO_SOLVER* solver, const char* key, int val )
+papilo_solver_set_param_int( PAPILO_SOLVER* solver, const char* key, int64_t val )
 {
    try
    {
@@ -832,7 +832,7 @@ papilo_solver_set_mip_param_real( PAPILO_SOLVER* solver, const char* key,
 
 PAPILO_PARAM_RESULT
 papilo_solver_set_mip_param_int( PAPILO_SOLVER* solver, const char* key,
-                                 int val )
+                                 int64_t val )
 {
    try
    {
@@ -976,7 +976,7 @@ papilo_solver_set_lp_param_real( PAPILO_SOLVER* solver, const char* key,
 
 PAPILO_PARAM_RESULT
 papilo_solver_set_lp_param_int( PAPILO_SOLVER* solver, const char* key,
-                                int val )
+                                int64_t val )
 {
    try
    {
@@ -1119,13 +1119,13 @@ papilo_solver_write_mps( PAPILO_SOLVER* solver, const char* filename )
    assert( solver->state == SolverState::PROBLEM_LOADED );
 
 #ifdef PAPILO_MPS_WRITER
-   Vec<int> rowmapping( solver->problem.getNRows() );
+   Vec<int64_t> rowmapping( solver->problem.getNRows() );
 
-   for( int i = 0; i != solver->problem.getNRows(); ++i )
+   for( int64_t i = 0; i != solver->problem.getNRows(); ++i )
       rowmapping[i] = i;
 
-   Vec<int> colmapping( solver->problem.getNCols() );
-   for( int i = 0; i != solver->problem.getNCols(); ++i )
+   Vec<int64_t> colmapping( solver->problem.getNCols() );
+   for( int64_t i = 0; i != solver->problem.getNCols(); ++i )
       colmapping[i] = i;
 
    MpsWriter<double>::writeProb( filename, solver->problem, rowmapping,

--- a/src/papilolib.h
+++ b/src/papilolib.h
@@ -50,8 +50,8 @@ extern "C"
    /// determine the finiteness of bounds and rowsides. The name pointer and
    /// the space hints are optional and can be NULL/0.
    PAPILOLIB_EXPORT PAPILO_PROBLEM*
-   papilo_problem_create( double infinity, const char* name, int nnz_hint,
-                          int row_hint, int col_hint );
+   papilo_problem_create( double infinity, const char* name, int64_t nnz_hint,
+                          int64_t row_hint, int64_t col_hint );
 
    /// Free the problem datastructure
    PAPILOLIB_EXPORT void
@@ -61,7 +61,7 @@ extern "C"
    /// new column or -1 if it does not exist (i.e. num == 0).
    /// If colnames is NULL generic names are used.
    PAPILOLIB_EXPORT int
-   papilo_problem_add_cols( PAPILO_PROBLEM* problem, int num, const double* lb,
+   papilo_problem_add_cols( PAPILO_PROBLEM* problem, int64_t num, const double* lb,
                             const double* ub, const unsigned char* integral,
                             const double* obj, const char** colnames );
 
@@ -86,27 +86,27 @@ extern "C"
 
    /// Change columns lower bound
    PAPILOLIB_EXPORT void
-   papilo_problem_change_col_lb( PAPILO_PROBLEM* problem, int col, double lb );
+   papilo_problem_change_col_lb( PAPILO_PROBLEM* problem, int64_t col, double lb );
 
    /// Change columns upper bound
    PAPILOLIB_EXPORT void
-   papilo_problem_change_col_ub( PAPILO_PROBLEM* problem, int col, double ub );
+   papilo_problem_change_col_ub( PAPILO_PROBLEM* problem, int64_t col, double ub );
 
    /// Change columns integrality restrictions
    PAPILOLIB_EXPORT void
-   papilo_problem_change_col_integral( PAPILO_PROBLEM* problem, int col,
+   papilo_problem_change_col_integral( PAPILO_PROBLEM* problem, int64_t col,
                                        unsigned char integral );
 
    /// Change columns objective coefficient
    PAPILOLIB_EXPORT void
-   papilo_problem_change_col_obj( PAPILO_PROBLEM* problem, int col,
+   papilo_problem_change_col_obj( PAPILO_PROBLEM* problem, int64_t col,
                                   double obj );
 
    /// Add simple linear constraints (no ranged rows) to the problem and returns
    /// the index of the first new row or -1 if it does not exist (i.e. num ==
    /// 0). If rownames is NULL generic names are used.
    PAPILOLIB_EXPORT int
-   papilo_problem_add_simple_rows( PAPILO_PROBLEM* problem, int num,
+   papilo_problem_add_simple_rows( PAPILO_PROBLEM* problem, int64_t num,
                                    const unsigned char* rowtypes,
                                    const double* side, const char** rownames );
 
@@ -116,7 +116,7 @@ extern "C"
    /// If rownames is NULL generic names are used. The rows can be a ranged row
    /// if both lhs and rhs are finite.
    PAPILOLIB_EXPORT int
-   papilo_problem_add_generic_rows( PAPILO_PROBLEM* problem, int num,
+   papilo_problem_add_generic_rows( PAPILO_PROBLEM* problem, int64_t num,
                                     const double* lhs, const double* rhs,
                                     const char** rownames );
 
@@ -136,25 +136,25 @@ extern "C"
 
    /// Add a nonzero entry for the given column to the given constraint
    PAPILOLIB_EXPORT void
-   papilo_problem_add_nonzero( PAPILO_PROBLEM* problem, int row, int col,
+   papilo_problem_add_nonzero( PAPILO_PROBLEM* problem, int64_t row, int64_t col,
                                double val );
 
    /// Add the nonzero entries for the given columns to the given row
    PAPILOLIB_EXPORT void
-   papilo_problem_add_nonzeros_row( PAPILO_PROBLEM* problem, int row, int num,
-                                    const int* cols, const double* vals );
+   papilo_problem_add_nonzeros_row( PAPILO_PROBLEM* problem, int64_t row, int64_t num,
+                                    const int64_t* cols, const double* vals );
 
    /// Add the nonzero entries for the given column to the given rows
    PAPILOLIB_EXPORT void
-   papilo_problem_add_nonzeros_col( PAPILO_PROBLEM* problem, int col, int num,
-                                    const int* rows, const double* vals );
+   papilo_problem_add_nonzeros_col( PAPILO_PROBLEM* problem, int64_t col, int64_t num,
+                                    const int64_t* rows, const double* vals );
 
    /// Add the nonzero entries given in compressed sparse row format. The array
    /// rowstart must have size at least nrows + 1 and the arrays cols and vals
    /// must have size at least rowstart[nrows].
    PAPILOLIB_EXPORT void
    papilo_problem_add_nonzeros_csr( PAPILO_PROBLEM* problem,
-                                    const int* rowstart, const int* cols,
+                                    const int64_t* rowstart, const int64_t* cols,
                                     const double* vals );
 
    /// Add the nonzero entries given in compressed sparse column format. The
@@ -162,7 +162,7 @@ extern "C"
    /// vals must have size at least colstart[ncols].
    PAPILOLIB_EXPORT void
    papilo_problem_add_nonzeros_csc( PAPILO_PROBLEM* problem,
-                                    const int* colstart, const int* rows,
+                                    const int64_t* colstart, const int64_t* rows,
                                     const double* vals );
 
    /// Solver type for presolve library
@@ -177,7 +177,7 @@ extern "C"
    /// 1 - errors, 2 - warnings, 3 - info, 4 - extra
    PAPILOLIB_EXPORT void
    papilo_solver_set_trace_callback( PAPILO_SOLVER* solver,
-                                     void ( *thetracecb )( int level,
+                                     void ( *thetracecb )( int64_t level,
                                                            const char* data,
                                                            size_t size,
                                                            void* usrptr ),
@@ -217,7 +217,7 @@ extern "C"
    /// Set integer parameter with given key to the given value
    PAPILOLIB_EXPORT PAPILO_PARAM_RESULT
    papilo_solver_set_param_int( PAPILO_SOLVER* solver, const char* key,
-                                int val );
+                                int64_t val );
 
    /// Set character parameter with given key to the given value
    PAPILOLIB_EXPORT PAPILO_PARAM_RESULT
@@ -237,7 +237,7 @@ extern "C"
    /// Set integer parameter with given key to the given value
    PAPILOLIB_EXPORT PAPILO_PARAM_RESULT
    papilo_solver_set_mip_param_int( PAPILO_SOLVER* solver, const char* key,
-                                    int val );
+                                    int64_t val );
 
    /// Set boolean parameter with given key to the given value
    PAPILOLIB_EXPORT PAPILO_PARAM_RESULT
@@ -267,7 +267,7 @@ extern "C"
    /// Set integer parameter with given key to the given value
    PAPILOLIB_EXPORT PAPILO_PARAM_RESULT
    papilo_solver_set_lp_param_int( PAPILO_SOLVER* solver, const char* key,
-                                   int val );
+                                   int64_t val );
 
    /// Set boolean parameter with given key to the given value
    PAPILOLIB_EXPORT PAPILO_PARAM_RESULT

--- a/test/CoefStren.cpp
+++ b/test/CoefStren.cpp
@@ -47,7 +47,7 @@ TEST_CASE( "test coefficient tightening reduction", "[core]" )
    Reductions<float> reductions;
 
    auto constraintchange = [&reductions](
-                               Action constchange, int i,
+                               Action constchange, int64_t i,
                                Vec<std::pair<int, float>> rowcoefchanges,
                                float newbound ) {
       assert( !rowcoefchanges.empty() );
@@ -71,7 +71,7 @@ TEST_CASE( "test coefficient tightening reduction", "[core]" )
    // 0 <= y <= 2
    // x,y integer
    float coefficients[] = {1, 2};
-   int indices[] = {0, 1};
+   int64_t indices[] = {0, 1};
    RowActivity<float> activity;
    activity.max = 6.0;
    activity.min = 0.0;

--- a/test/Common.cpp
+++ b/test/Common.cpp
@@ -27,13 +27,13 @@
 
 TEST_CASE( "test activity computation and constraint propagation", "[core]" )
 {
-   Vec<int> colinds{0, 1, 2, 3, 4, 5, 6, 7};
+   Vec<int64_t> colinds{0, 1, 2, 3, 4, 5, 6, 7};
    Vec<double> rowvalues{1.0, -1.0, 2.0, -2.0, 3.0, -3.0, 4.0, -4.0};
 
    Vec<double> lbs{0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
    Vec<double> ubs{1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0};
 
-   int colrows = 0;
+   int64_t colrows = 0;
 
    Vec<RowActivity<double>> activities;
    activities.emplace_back( compute_row_activity(
@@ -44,9 +44,9 @@ TEST_CASE( "test activity computation and constraint propagation", "[core]" )
    REQUIRE( activities[0].min == -activities[0].max );
    REQUIRE( activities[0].max == ( 1.0 + 2.0 + 3.0 + 4.0 ) );
 
-   int ncalls = 0;
+   int64_t ncalls = 0;
    // fix column 0 to upper bound
-   auto activity_callback = [&]( ActivityChange actChange, int row,
+   auto activity_callback = [&]( ActivityChange actChange, int64_t row,
                                  RowActivity<double>& activity ) {
       REQUIRE( row == 0 );
       REQUIRE( &activity == &activities[0] );
@@ -144,7 +144,7 @@ TEST_CASE( "test activity computation and constraint propagation", "[core]" )
    ncalls = 0;
    propagate_row( rowvalues.data(), colinds.data(), rowvalues.size(),
                   activities[0], -infinity<double>(), activities[0].min, lbs,
-                  ubs, [&]( BoundChange bndChg, int colid, double newbnd ) {
+                  ubs, [&]( BoundChange bndChg, int64_t colid, double newbnd ) {
                      if( bndChg == BoundChange::kLower )
                      {
                         lbs_cpy[colid] = newbnd;
@@ -177,7 +177,7 @@ TEST_CASE( "test activity computation and constraint propagation", "[core]" )
    ncalls = 0;
    propagate_row( rowvalues.data(), colinds.data(), rowvalues.size(),
                   activities[0], activities[0].max, infinity<double>(), lbs,
-                  ubs, [&]( BoundChange bndChg, int colid, double newbnd ) {
+                  ubs, [&]( BoundChange bndChg, int64_t colid, double newbnd ) {
                      if( bndChg == BoundChange::kLower )
                      {
                         lbs_cpy[colid] = newbnd;

--- a/test/MatrixBuffer.cpp
+++ b/test/MatrixBuffer.cpp
@@ -38,10 +38,10 @@ checkHeapProperty( MatrixBuffer<double>& M )
    else
       fmt::print( "check col major heap property\n" );
 
-   for( int i = 1; i != M.entries.size(); ++i )
+   for( int64_t i = 1; i != M.entries.size(); ++i )
    {
-      int left = Node::left( M.entries[i] );
-      int right = Node::right( M.entries[i] );
+      int64_t left = Node::left( M.entries[i] );
+      int64_t right = Node::right( M.entries[i] );
 
       if( ( left != 0 && Node::priority( M.entries[i] ) <
                              Node::priority( M.entries[left] ) ) ||
@@ -65,10 +65,10 @@ checkBstProperty( MatrixBuffer<double>& M )
 {
    using Node = GetNodeProperty<StorageOrder>;
 
-   for( int i = 1; i != M.entries.size(); ++i )
+   for( int64_t i = 1; i != M.entries.size(); ++i )
    {
-      int left = Node::left( M.entries[i] );
-      int right = Node::right( M.entries[i] );
+      int64_t left = Node::left( M.entries[i] );
+      int64_t right = Node::right( M.entries[i] );
 
       if( left != 0 && Node::lesser( M.entries[i], M.entries[left] ) )
          return false;
@@ -139,7 +139,7 @@ TEST_CASE( "matrix-buffer", "[core]" )
    REQUIRE( checkBstProperty<true>( M ) );
    REQUIRE( checkBstProperty<false>( M ) );
 
-   int i = 1;
+   int64_t i = 1;
 
    while( it != M.end() )
    {

--- a/test/PapiloLib.cpp
+++ b/test/PapiloLib.cpp
@@ -27,8 +27,8 @@
 
 TEST_CASE( "papilolib", "[C-API]" )
 {
-   constexpr int num_facilities = 25;
-   constexpr int num_customers = 50;
+   constexpr int64_t num_facilities = 25;
+   constexpr int64_t num_customers = 50;
 
    double facility_fixcost[] = {
        7500.0, 7500.0, 7500.0, 7500.0, 7500.0, 7500.0, 7500.0, 7500.0, 7500.0,
@@ -300,8 +300,8 @@ TEST_CASE( "papilolib", "[C-API]" )
         50787.21250,  41538.43750,  17905.93750, 25093.75000,  187935.86250,
         59235.56250,  16219.87500,  3300.76250,  11949.90000,  9376.72500}};
 
-   constexpr int nvars = num_facilities * num_customers + num_facilities;
-   constexpr int nrows = num_facilities + num_customers;
+   constexpr int64_t nvars = num_facilities * num_customers + num_facilities;
+   constexpr int64_t nrows = num_facilities + num_customers;
 
    unsigned char integral[nvars];
    double lbs[nvars];
@@ -316,17 +316,17 @@ TEST_CASE( "papilolib", "[C-API]" )
    const char* rownames[num_customers + num_facilities];
 
    // all vars binary
-   int nassignvars = nvars - num_facilities;
+   int64_t nassignvars = nvars - num_facilities;
 
-   int i = 0;
+   int64_t i = 0;
    for( ; i != nassignvars; ++i )
    {
       integral[i] = 1;
       lbs[i] = 0;
       ubs[i] = 1;
 
-      int f = i / num_customers;
-      int c = i - num_customers * f;
+      int64_t f = i / num_customers;
+      int64_t c = i - num_customers * f;
       obj[i] = facility_customer_service_cost[f][c];
       names.emplace_back( fmt::format( "x#{}#{}", f + 1, c + 1 ) );
       colnames[i] = names.back().c_str();
@@ -338,7 +338,7 @@ TEST_CASE( "papilolib", "[C-API]" )
       lbs[i] = 0;
       ubs[i] = 1;
 
-      int f = i - nassignvars;
+      int64_t f = i - nassignvars;
       assert( 0 <= f && f < num_facilities );
       obj[i] = facility_fixcost[f];
       names.emplace_back( fmt::format( "y#{}", f + 1 ) );
@@ -373,21 +373,21 @@ TEST_CASE( "papilolib", "[C-API]" )
    for( i = 0; i != num_facilities; ++i )
       assign_nonzeros[i] = 1.0;
 
-   int assign_nonzero_inds[num_facilities];
+   int64_t assign_nonzero_inds[num_facilities];
    for( i = 0; i != num_customers; ++i )
    {
-      for( int j = 0; j != num_facilities; ++j )
+      for( int64_t j = 0; j != num_facilities; ++j )
          assign_nonzero_inds[j] = i + j * num_customers;
 
       papilo_problem_add_nonzeros_row( prob, i, num_facilities,
                                        assign_nonzero_inds, assign_nonzeros );
    }
 
-   int capacity_nonzero_inds[num_customers + 1];
+   int64_t capacity_nonzero_inds[num_customers + 1];
    for( ; i != nrows; ++i )
    {
-      int f = i - num_customers;
-      for( int j = 0; j != num_customers; ++j )
+      int64_t f = i - num_customers;
+      for( int64_t j = 0; j != num_customers; ++j )
          capacity_nonzero_inds[j] = j + f * num_customers;
 
       capacity_nonzero_inds[num_customers] = nassignvars + f;
@@ -455,7 +455,7 @@ TEST_CASE( "papilolib", "[C-API]" )
    REQUIRE( sol != nullptr );
 
    double objval = 0;
-   for( int i = 0; i != nvars; ++i )
+   for( int64_t i = 0; i != nvars; ++i )
       objval += obj[i] * sol[i];
    REQUIRE( objval == Approx( 796648.4375 ) );
 

--- a/test/ParallelRows.cpp
+++ b/test/ParallelRows.cpp
@@ -45,31 +45,31 @@ TEST_CASE( "Parallel row detection", "[core]" )
 {
    double coef1[] = {1, 1, 1, 1, 1};
    double coef2[] = {2, 2, 2, 2, 2};
-   int id1[] = {1, 2, 3, 4, 5};
-   int id2[] = {1, 2, 3, 4, 5};
+   int64_t id1[] = {1, 2, 3, 4, 5};
+   int64_t id2[] = {1, 2, 3, 4, 5};
 
    double coef3[] = {1.5, -1.5, 1.5, 1.5, -1.5};
    double coef4[] = {-1, 1, -1, -1, 1};
-   int id3[] = {1, 2, 3, 4, 5};
-   int id4[] = {1, 2, 3, 4, 5};
+   int64_t id3[] = {1, 2, 3, 4, 5};
+   int64_t id4[] = {1, 2, 3, 4, 5};
 
    double coef5[] = {1, 1, 1, 1, 1};
-   int id5[] = {1, 2, 4, 6, 9};
+   int64_t id5[] = {1, 2, 4, 6, 9};
 
    double coef6[] = {1, 1, 1, -1, -1};
    double coef7[] = {2, 2, 2, -2, -2};
-   int id6[] = {1, 2, 4, 5, 6};
-   int id7[] = {1, 2, 4, 5, 6};
+   int64_t id6[] = {1, 2, 4, 5, 6};
+   int64_t id7[] = {1, 2, 4, 5, 6};
 
    double coef8[] = {1, 1, -1, -1, -1};
    double coef9[] = {1.0000001, 1, -1, -1, -1};
-   int id8[] = {1, 2, 4, 5, 6};
-   int id9[] = {1, 2, 4, 5, 6};
+   int64_t id8[] = {1, 2, 4, 5, 6};
+   int64_t id9[] = {1, 2, 4, 5, 6};
 
    const double* coefs[] = {coef1, coef2, coef3, coef4, coef5,
                             coef6, coef7, coef8, coef9};
-   const int* ids[] = {id1, id2, id3, id4, id5, id6, id7, id8, id9};
-   const int lens[] = {5, 5, 5, 5, 5, 5, 5, 5, 5};
+   const int64_t* ids[] = {id1, id2, id3, id4, id5, id6, id7, id8, id9};
+   const int64_t lens[] = {5, 5, 5, 5, 5, 5, 5, 5, 5};
 
    double inf = infinity<double>();
    Vec<double> lhs_values{-1, -2, 0, -1, -1, -inf, -inf, -1, -3};
@@ -80,7 +80,7 @@ TEST_CASE( "Parallel row detection", "[core]" )
 
    // test lambda used in the presolver
    auto handlerows = [&reductions, &result, &lhs_values,
-                      &rhs_values]( int row1, int row2, double ratio ) {
+                      &rhs_values]( int64_t row1, int64_t row2, double ratio ) {
       bool firstconsEquality = ( rhs_values[row1] == lhs_values[row1] );
       bool secondconsEquality = ( rhs_values[row2] == lhs_values[row2] );
       assert( ratio != 0.0 );

--- a/test/SparseStorage.cpp
+++ b/test/SparseStorage.cpp
@@ -35,8 +35,8 @@ TEST_CASE( "sparse storage can be created from triplets and compressed",
    // 0  8  0  0  0  0  0  0  0
    // 0  0  0  0  0  0  0  0  0
    // 9  10 11 0  0  0  0  12 13
-   int nrows = 5;
-   int ncols = 9;
+   int64_t nrows = 5;
+   int64_t ncols = 9;
    Vec<Triplet<double>> triplets = {
        Triplet<double>{0, 0, 1.0},  Triplet<double>{0, 1, 2.0},
        Triplet<double>{1, 1, 3.0},  Triplet<double>{1, 2, 4.0},
@@ -46,8 +46,8 @@ TEST_CASE( "sparse storage can be created from triplets and compressed",
        Triplet<double>{4, 2, 11.0}, Triplet<double>{4, 7, 12.0},
        Triplet<double>{4, 8, 13.0}};
 
-   Vec<int> rowsize = {2, 5, 1, -1, 5};
-   Vec<int> colsize = {2, 4, 2, 1, 1, 1, -1, 1, 1};
+   Vec<int64_t> rowsize = {2, 5, 1, -1, 5};
+   Vec<int64_t> colsize = {2, 4, 2, 1, 1, 1, -1, 1, 1};
    SparseStorage<double> matrix{triplets, nrows, ncols, true};
    SparseStorage<double> transpose = matrix.getTranspose();
 
@@ -62,11 +62,11 @@ TEST_CASE( "sparse storage can be created from triplets and compressed",
    auto rowranges = matrix.getRowRanges();
    auto rowvalues = matrix.getValues();
    auto columns = matrix.getColumns();
-   for( int i = 0; i < nrows; ++i )
+   for( int64_t i = 0; i < nrows; ++i )
    {
       REQUIRE( rowranges[i].end - rowranges[i].start == rowsize[i] );
       double* row = rowvalues + rowranges[i].start;
-      int* rowcols = columns + rowranges[i].start;
+      int64_t* rowcols = columns + rowranges[i].start;
       switch( i )
       {
       case 0:
@@ -112,11 +112,11 @@ TEST_CASE( "sparse storage can be created from triplets and compressed",
    auto colranges = transpose.getRowRanges();
    auto colvalues = transpose.getValues();
    auto rows = transpose.getColumns();
-   for( int i = 0; i < ncols; ++i )
+   for( int64_t i = 0; i < ncols; ++i )
    {
       REQUIRE( colranges[i].end - colranges[i].start == colsize[i] );
       double* col = colvalues + colranges[i].start;
-      int* colrows = rows + colranges[i].start;
+      int64_t* colrows = rows + colranges[i].start;
       switch( i )
       {
       case 0:
@@ -166,14 +166,14 @@ TEST_CASE( "sparse storage can be created from triplets and compressed",
       }
    }
 
-   Vec<int> col_mapping = matrix.compress( colsize );
-   Vec<int> row_mapping = transpose.compress( rowsize );
+   Vec<int64_t> col_mapping = matrix.compress( colsize );
+   Vec<int64_t> row_mapping = transpose.compress( rowsize );
 
    REQUIRE( col_mapping.size() == ncols );
    REQUIRE( row_mapping.size() == nrows );
 
    /* check if empty row at index 3 was removed properly */
-   for( int i = 0; i < nrows; ++i )
+   for( int64_t i = 0; i < nrows; ++i )
    {
       if( i < 3 )
          REQUIRE( row_mapping[i] == i );
@@ -184,7 +184,7 @@ TEST_CASE( "sparse storage can be created from triplets and compressed",
    }
 
    /* check if empty col at index 6 was removed properly */
-   for( int i = 0; i < ncols; ++i )
+   for( int64_t i = 0; i < ncols; ++i )
    {
       if( i < 6 )
          REQUIRE( col_mapping[i] == i );
@@ -203,11 +203,11 @@ TEST_CASE( "sparse storage can be created from triplets and compressed",
    rowranges = matrix.getRowRanges();
    rowvalues = matrix.getValues();
    columns = matrix.getColumns();
-   for( int i = 0; i < nrows; ++i )
+   for( int64_t i = 0; i < nrows; ++i )
    {
       REQUIRE( rowranges[i].end - rowranges[i].start == rowsize[i] );
       double* row = rowvalues + rowranges[i].start;
-      int* rowcols = columns + rowranges[i].start;
+      int64_t* rowcols = columns + rowranges[i].start;
       switch( i )
       {
       case 0:
@@ -251,11 +251,11 @@ TEST_CASE( "sparse storage can be created from triplets and compressed",
    colranges = transpose.getRowRanges();
    colvalues = transpose.getValues();
    rows = transpose.getColumns();
-   for( int i = 0; i < ncols; ++i )
+   for( int64_t i = 0; i < ncols; ++i )
    {
       REQUIRE( colranges[i].end - colranges[i].start == colsize[i] );
       double* col = colvalues + colranges[i].start;
-      int* colrows = rows + colranges[i].start;
+      int64_t* colrows = rows + colranges[i].start;
       switch( i )
       {
       case 0:

--- a/test/VectorUtils.cpp
+++ b/test/VectorUtils.cpp
@@ -49,8 +49,8 @@ TEST_CASE( "matrix-comparisons", "[misc]" )
    // 0  8  0  0  0  0  0  0  0
    // 0  0  0  0  0  0  0  0  0
    // 9  10 11 0  0  0  0  12 13
-   int nrows = 5;
-   int ncols = 9;
+   int64_t nrows = 5;
+   int64_t ncols = 9;
    Vec<Triplet<double>> triplets = {
        Triplet<double>{0, 0, 1.0},  Triplet<double>{0, 1, 2.0},
        Triplet<double>{1, 1, 3.0},  Triplet<double>{1, 2, 4.0},
@@ -60,8 +60,8 @@ TEST_CASE( "matrix-comparisons", "[misc]" )
        Triplet<double>{4, 2, 11.0}, Triplet<double>{4, 7, 12.0},
        Triplet<double>{4, 8, 13.0}};
 
-   Vec<int> rowsize = {2, 5, 1, -1, 5};
-   Vec<int> colsize = {2, 4, 2, 1, 1, 1, -1, 1, 1};
+   Vec<int64_t> rowsize = {2, 5, 1, -1, 5};
+   Vec<int64_t> colsize = {2, 4, 2, 1, 1, 1, -1, 1, 1};
    SparseStorage<double> matrix{triplets, nrows, ncols, true};
    SparseStorage<double> transpose = matrix.getTranspose();
 
@@ -98,16 +98,16 @@ TEST_CASE( "problem-comparisons", "[misc]" )
    // 1  2  0  0
    // 0  3  4  5
    // 0  8  0  1
-   int nrows = 3;
-   int ncols = 4;
+   int64_t nrows = 3;
+   int64_t ncols = 4;
    Vec<Triplet<double>> triplets = {
        Triplet<double>{0, 0, 1.0}, Triplet<double>{0, 1, 2.0},
        Triplet<double>{1, 1, 3.0}, Triplet<double>{1, 2, 4.0},
        Triplet<double>{1, 3, 5.0}, Triplet<double>{2, 1, 8.0},
        Triplet<double>{2, 3, 1.0}};
 
-   Vec<int> rowsize = {2, 3, 2};
-   Vec<int> colsize = {1, 3, 1, 2};
+   Vec<int64_t> rowsize = {2, 3, 2};
+   Vec<int64_t> colsize = {1, 3, 1, 2};
    SparseStorage<double> matrix{triplets, nrows, ncols, true};
 
    Vec<double> lhs{0, 1, 2};

--- a/test/instances/bell5.hpp
+++ b/test/instances/bell5.hpp
@@ -425,8 +425,8 @@ bell5()
        "f1",  "f2",  "f3",  "f4",  "f5",  "f6",  "f7",  "f9",  "f10", "f11",
        "f12", "f13", "f14", "f16",
    };
-   int nCols = 104;
-   int nRows = 91;
+   int64_t nCols = 104;
+   int64_t nRows = 91;
    ProblemBuilder<double> pb;
    pb.reserve( 266, 91, 104 );
    pb.setNumRows( nRows );

--- a/test/instances/blend2.hpp
+++ b/test/instances/blend2.hpp
@@ -1771,8 +1771,8 @@ blend2()
        "VV620", "VV621", "VV622", "VV623", "VV624", "VV625", "VV626", "VV627",
        "VV628",
    };
-   int nCols = 353;
-   int nRows = 274;
+   int64_t nCols = 353;
+   int64_t nRows = 274;
    ProblemBuilder<double> pb;
    pb.reserve( 1409, 274, 353 );
    pb.setNumRows( nRows );

--- a/test/instances/dcmulti.hpp
+++ b/test/instances/dcmulti.hpp
@@ -1765,8 +1765,8 @@ dcmulti()
        "Z4123", "Z4213", "Z4223", "Z5113", "Z5123", "Z5213", "Z5223", "W13",
        "W23",   "W33",   "W43",   "W53",
    };
-   int nCols = 548;
-   int nRows = 290;
+   int64_t nCols = 548;
+   int64_t nRows = 290;
    ProblemBuilder<double> pb;
    pb.reserve( 1315, 290, 548 );
    pb.setNumRows( nRows );

--- a/test/instances/egout.hpp
+++ b/test/instances/egout.hpp
@@ -468,8 +468,8 @@ egout()
        "F.035036", "F.037038", "F.038040", "F.039040", "F.040...", "F.041...",
        "F.040041", "F.041042", "F.042...",
    };
-   int nCols = 141;
-   int nRows = 98;
+   int64_t nCols = 141;
+   int64_t nRows = 98;
    ProblemBuilder<double> pb;
    pb.reserve( 282, 98, 141 );
    pb.setNumRows( nRows );

--- a/test/instances/enigma.hpp
+++ b/test/instances/enigma.hpp
@@ -409,8 +409,8 @@ enigma()
        "I0",  "I1",  "I2",  "I3",  "I4",  "I5",  "I6",  "I7",  "I8",  "I9",
        "L0",  "L1",  "L2",  "L3",  "L4",  "L5",  "L6",  "L7",  "L8",  "L9",
    };
-   int nCols = 100;
-   int nRows = 21;
+   int64_t nCols = 100;
+   int64_t nRows = 21;
    ProblemBuilder<double> pb;
    pb.reserve( 289, 21, 100 );
    pb.setNumRows( nRows );

--- a/test/instances/flugpl.hpp
+++ b/test/instances/flugpl.hpp
@@ -127,8 +127,8 @@ flugpl()
        "STM1", "ANM1", "UE1", "STM2", "ANM2", "UE2", "STM3", "ANM3", "UE3",
        "STM4", "ANM4", "UE4", "STM5", "ANM5", "UE5", "STM6", "ANM6", "UE6",
    };
-   int nCols = 18;
-   int nRows = 18;
+   int64_t nCols = 18;
+   int64_t nRows = 18;
    ProblemBuilder<double> pb;
    pb.reserve( 46, 18, 18 );
    pb.setNumRows( nRows );

--- a/test/instances/gt2.hpp
+++ b/test/instances/gt2.hpp
@@ -560,8 +560,8 @@ gt2()
        "x...1210", "x...1211", "x...1212", "x...1213", "x...1214", "x...1215",
        "x...1216", "x...1217",
    };
-   int nCols = 188;
-   int nRows = 29;
+   int64_t nCols = 188;
+   int64_t nRows = 29;
    ProblemBuilder<double> pb;
    pb.reserve( 376, 29, 188 );
    pb.setNumRows( nRows );

--- a/test/instances/lseu.hpp
+++ b/test/instances/lseu.hpp
@@ -430,8 +430,8 @@ lseu()
        "C173", "C174", "C175", "C176", "C177", "C178", "C179", "C180", "C181",
        "C182", "C183", "C184", "C185", "C186", "C187", "C188", "C189",
    };
-   int nCols = 89;
-   int nRows = 28;
+   int64_t nCols = 89;
+   int64_t nRows = 28;
    ProblemBuilder<double> pb;
    pb.reserve( 309, 28, 89 );
    pb.setNumRows( nRows );

--- a/test/instances/misc03.hpp
+++ b/test/instances/misc03.hpp
@@ -2232,8 +2232,8 @@ misc03()
        "COL148", "COL149", "COL150", "COL151", "COL152", "COL153", "COL154",
        "COL155", "COL156", "COL157", "COL158", "COL159", "COL160",
    };
-   int nCols = 160;
-   int nRows = 96;
+   int64_t nCols = 160;
+   int64_t nRows = 96;
    ProblemBuilder<double> pb;
    pb.reserve( 2053, 96, 160 );
    pb.setNumRows( nRows );

--- a/test/instances/p0548.hpp
+++ b/test/instances/p0548.hpp
@@ -2125,8 +2125,8 @@ p0548()
        "C1537", "C1538", "C1539", "C1540", "C1541", "C1542", "C1543", "C1544",
        "C1545", "C1546", "C1547", "C1548",
    };
-   int nCols = 548;
-   int nRows = 176;
+   int64_t nCols = 548;
+   int64_t nRows = 176;
    ProblemBuilder<double> pb;
    pb.reserve( 1711, 176, 548 );
    pb.setNumRows( nRows );

--- a/test/instances/rgn.hpp
+++ b/test/instances/rgn.hpp
@@ -618,8 +618,8 @@ rgn()
        "WA3",  "WA4",  "WB1",  "WB2",  "WB3",  "WB4",  "WC1",  "WC2",  "WC3",
        "WC4",  "WD1",  "WD2",  "WD3",  "WD4",  "WE1",  "WE2",  "WE3",  "WE4",
    };
-   int nCols = 180;
-   int nRows = 24;
+   int64_t nCols = 180;
+   int64_t nRows = 24;
    ProblemBuilder<double> pb;
    pb.reserve( 460, 24, 180 );
    pb.setNumRows( nRows );


### PR DESCRIPTION
Closes #41

Tests are passing with Soplex and SCIP. I didn't actually try an instance that exceeds 2 billion variables/constraints.

TODOs:
- [ ] The interface with HiGHS should be tested. It's probably broken.
- [x] Is the `HitCount` typedef in Sparsify.hpp safe as an int16?

Before merging, I recommend:
- Checking the changes very carefully
- Running benchmarks (are there standard ones?) to check if there's a performance loss in common case where 32-bit integers would be sufficient

Minor: 
- The code calling LUSOL might not need to make an extra copy of the matrix anymore.