### PR TITLE
get githash

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,10 +60,9 @@ find_program(GIT git)
 
 if((GIT) AND (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/.git))
    execute_process(
-      COMMAND ${GIT} describe --always --dirty
+      COMMAND ${GIT} rev-parse --short HEAD
       WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
       OUTPUT_VARIABLE PAPILO_GITHASH OUTPUT_STRIP_TRAILING_WHITESPACE)
-   string(REGEX REPLACE \"^.*-g\" \"\" PAPILO_GITHASH ${PAPILO_GITHASH})
 else()
    file(STRINGS ${CMAKE_CURRENT_SOURCE_DIR}/src/papilo/Config.hpp githash_define REGEX "define PAPILO_GITHASH .*")
    if(githash_define)

--- a/makedist.sh
+++ b/makedist.sh
@@ -8,7 +8,7 @@ rm -f $NAME.tar
 echo ">>> Packaging $NAME."
 
 # echo "store git hash"
-GITHASH=`git describe --always --dirty --tag | sed 's/^.*-g//'`
+GITHASH=`git rev-parse --short HEAD`
 sed -i "s/undef PAPILO_GITHASH_AVAILABLE/define PAPILO_GITHASH_AVAILABLE/g" src/papilo/Config.hpp
 sed -i "s/undef PAPILO_GITHASH/define PAPILO_GITHASH \"$GITHASH\"/g" src/papilo/Config.hpp
 

--- a/makedist.sh
+++ b/makedist.sh
@@ -8,7 +8,7 @@ rm -f $NAME.tar
 echo ">>> Packaging $NAME."
 
 # echo "store git hash"
-GITHASH=`git describe --always --dirty  | sed 's/^.*-g//'`
+GITHASH=`git describe --always --dirty --tag | sed 's/^.*-g//'`
 sed -i "s/undef PAPILO_GITHASH_AVAILABLE/define PAPILO_GITHASH_AVAILABLE/g" src/papilo/Config.hpp
 sed -i "s/undef PAPILO_GITHASH/define PAPILO_GITHASH \"$GITHASH\"/g" src/papilo/Config.hpp
 


### PR DESCRIPTION
formerly we got a description that contained the most recent annotated tag. Now `CMakeLists.txt` and `makedist.sh` parse the githash via the `git --rev-parse --short HEAD` command which seems to be a bit more robust.